### PR TITLE
Make connection timeout configurable

### DIFF
--- a/cmd/composectl/cmd/check.go
+++ b/cmd/composectl/cmd/check.go
@@ -144,7 +144,7 @@ func checkApps(ctx context.Context, appRefs []string, usageWatermark uint, srcSt
 		blobProvider = compose.NewStoreBlobProvider(path.Join(srcStorePath, "blobs", "sha256"))
 	} else {
 		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer)
+		resolver := compose.NewResolver(authorizer, config.ConnectTime)
 		blobProvider = compose.NewRemoteBlobProvider(resolver)
 	}
 

--- a/cmd/composectl/cmd/config.go
+++ b/cmd/composectl/cmd/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	DockerCfg   *configfile.ConfigFile
 	DockerHost  string
 	Platform    specs.Platform
+	ConnectTime int
 }
 
 var (

--- a/cmd/composectl/cmd/inspect.go
+++ b/cmd/composectl/cmd/inspect.go
@@ -24,7 +24,7 @@ func inspectApp(cmd *cobra.Command, args []string) {
 	appRef := args[0]
 
 	authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-	resolver := compose.NewResolver(authorizer)
+	resolver := compose.NewResolver(authorizer, config.ConnectTime)
 	fmt.Printf("Inspecting App %s...", appRef)
 	_, tree, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), compose.NewRemoteBlobProvider(resolver), platforms.All, appRef)
 	DieNotNil(err)

--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -57,7 +57,7 @@ func pullApps(cmd *cobra.Command, args []string) {
 		//  1) Copy in multiple goroutines/workers (configurable)
 		//  2) Generic status reporting mechanism
 		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer)
+		resolver := compose.NewResolver(authorizer, config.ConnectTime)
 
 		ls, err := local.NewStore(config.StoreRoot)
 		DieNotNil(err)

--- a/cmd/composectl/cmd/root.go
+++ b/cmd/composectl/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	"os"
 	"path"
+	"strconv"
 )
 
 const (
@@ -19,6 +20,8 @@ var (
 	composeRoot       string
 	arch              string
 	dockerHost        string
+	connectTimeout    int
+	defConnectTimeout string
 
 	rootCmd = &cobra.Command{
 		Use:   "composectl",
@@ -55,11 +58,19 @@ func init() {
 		}
 		composeRoot = path.Join(homeDir, ".composeapps/projects")
 	}
+	var err error
+	defConnectTimeoutValue := 30
+	if len(defConnectTimeout) > 0 {
+		fmt.Println(defConnectTimeout)
+		defConnectTimeoutValue, err = strconv.Atoi(defConnectTimeout)
+		DieNotNil(err)
+	}
 
 	rootCmd.PersistentFlags().StringVarP(&config.StoreRoot, "store", "s", storeRoot, "store root path")
 	rootCmd.PersistentFlags().StringVarP(&config.ComposeRoot, "compose", "i", composeRoot, "compose projects root path")
 	rootCmd.PersistentFlags().StringVarP(&arch, "arch", "a", "", "architecture of app/images to pull")
 	rootCmd.PersistentFlags().StringVarP(&dockerHost, "host", "H", "", "path to the socket on which the Docker daemon listens")
+	rootCmd.PersistentFlags().IntVarP(&connectTimeout, "connect-timeout", "", defConnectTimeoutValue, "timeout for connecting to a container registry service")
 }
 
 func initConfig() {
@@ -76,4 +87,5 @@ func initConfig() {
 	if len(arch) > 0 {
 		config.Platform.Architecture = arch
 	}
+	config.ConnectTime = connectTimeout
 }

--- a/pkg/compose/resolver.go
+++ b/pkg/compose/resolver.go
@@ -3,12 +3,23 @@ package compose
 import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
+	"net"
+	"net/http"
+	"time"
 )
 
-func NewResolver(authorizer docker.Authorizer) remotes.Resolver {
+func NewResolver(authorizer docker.Authorizer, connectTimeout int) remotes.Resolver {
 	ropts := []docker.RegistryOpt{
 		docker.WithAuthorizer(authorizer),
+		docker.WithClient(&http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout: time.Duration(connectTimeout) * time.Second,
+				}).DialContext,
+			},
+		}),
 	}
+	//TODO: consider using options.Hosts = config.ConfigureHosts(ctx, hostOptions)
 	return docker.NewResolver(docker.ResolverOptions{
 		Hosts: docker.ConfigureDefaultRegistries(ropts...),
 	},


### PR DESCRIPTION
Allow user to define a default and command specific timeout for connection to container registry.