### PR TITLE
check: Check "familiar" ref in addition to cannonical

### DIFF
--- a/cmd/composectl/cmd/check.go
+++ b/cmd/composectl/cmd/check.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/reference"
+	"github.com/containerd/containerd/reference/docker"
 	dockertypes "github.com/docker/docker/api/types"
 	"github.com/docker/go-units"
 	"github.com/foundriesio/composeapp/pkg/compose"
@@ -266,7 +267,13 @@ func checkIfInstalled(ctx context.Context, appRefs []string, srcStorePath string
 				if s, err := reference.Parse(imageUri); err == nil {
 					taggedUri := s.Locator + ":" + (s.Digest().Encoded())[:7]
 					if !installedImages[taggedUri] {
-						missingImages = append(missingImages, imageUri)
+						// Check familiar name
+						if anyRef, err := docker.ParseAnyReference(imageUri); err == nil {
+							familiarRef := docker.FamiliarString(anyRef)
+							if !installedImages[familiarRef] {
+								missingImages = append(missingImages, imageUri)
+							}
+						}
 					}
 				}
 			}


### PR DESCRIPTION
If images are hosted in docker.io registry then they can be referenced by a short (aka "familiar") URI format.
For example, "docker.io/library/nginx:stable-alpine" or "docker.io/homeassistant/home-assistant:stable" can be referenced as "nginx:stable-alpine" and  "homeassistant/home-assistant:stable" respectively.

The dockerd removes the "docker.io" or "docker.io/library" prefix when stores images in its store and as result returns the image URIs in the shorten format in a response to "http://localhost/images/json?all=1" request. For example, "nginx@sha256:<hash>" or
"homeassistant/home-assistant:<hash>".

The given change checks if the "familiar"/shorten image URI is present in the image map returned by dockerd in addition to checking the regular image URI as it is specified in a compose project and the tagged image URI.