### PR TITLE
Improve err if app missing

### DIFF
--- a/pkg/compose/v1/app_store.go
+++ b/pkg/compose/v1/app_store.go
@@ -203,7 +203,7 @@ func (s *appStore) GetReadCloser(ctx context.Context, opts ...compose.SecureRead
 	}
 
 	f, fileOpenErr := os.Open(blobPath)
-	if checkHash {
+	if checkHash && fileOpenErr == nil {
 		newOpts := opts
 		p := compose.GetSecureReadParams(opts...)
 		if len(p.ExpectedDigest) == 0 {


### PR DESCRIPTION
There is no point to continue with blob reading if a failure to open blob file occurs.

This improves error logging in case if an app is missing, or its manifest is missing to be precise.

Instead of `ERROR: invalid argument` the error log will look like:

`ERROR: failed to read app manifest: open <>/reset-apps/apps/http-server/7cc3a4c85b1d5ad40fe52c196b2a31388a010b720970480d11ee99dfa3dae113/manifest.json: no such file or directory`