### PR TITLE
Test publish with layers meta

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,8 +51,8 @@ check_connect_timeout:
 format:
 	@$(GO) fmt ./...
 
-test:
-	@$(GO) test ./...
+test-unit:
+	@$(GO) test -v ./pkg/compose/...
 
 $(bd):
 	@mkdir -p $@
@@ -69,9 +69,12 @@ check: format
 tidy-mod:
 	go mod tidy -go=$(MODVER)
 
+# the followinf targets should be run only in the dev container
 preload-images:
 	test/fixtures/preload-images.sh
 
-# target should be run only in the dev container
 test-e2e: $(exe) preload-images
-	go test -v ./...
+	@$(GO) test -v ./...
+
+test-smoke: $(exe) preload-images
+	@$(GO) test -v -run TestSmoke test/integration/smoke_test.go

--- a/dev-shell.sh
+++ b/dev-shell.sh
@@ -1,7 +1,7 @@
 down() {
     docker compose --env-file=test/compose/.env.test -f test/compose/docker-compose.yml down --remove-orphans
 	# remove the docker runtime and compose app store volumes
-    docker volume rm compose_docker-runtime compose_reset-apps
+    docker volume rm compose_docker-data compose_docker-runtime compose_reset-apps
 }
 
 trap down EXIT

--- a/test/compose/Dockerfile
+++ b/test/compose/Dockerfile
@@ -3,7 +3,12 @@ FROM golang:1.22-alpine
 ARG REG_CERT=test/compose/registry/certs/registry.crt
 ARG SRC_DIR=$PWD
 
-RUN apk add make curl docker docker-compose git
+RUN apk add make curl docker docker-compose git python3 py3-requests py3-expandvars py3-yaml
+
+# fetch ci-scripts, needed for calculating sizes of extacted app layers
+RUN git clone https://github.com/foundriesio/ci-scripts.git /ci-scripts
+ENV PYTHONPATH=/ci-scripts
+ENV LAYERS_SIZE_SCRIPT=/ci-scripts/apps/get_layers_meta.py
 
 COPY $REG_CERT /etc/ssl/certs/registry.crt
 RUN cat /etc/ssl/certs/registry.crt >> /etc/ssl/certs/ca-certificates.crt

--- a/test/compose/docker-compose.yml
+++ b/test/compose/docker-compose.yml
@@ -17,6 +17,7 @@ services:
     privileged: true
     volumes:
       - docker-runtime:/var/run/docker
+      - docker-data:/var/lib/docker
       - ${REG_DIR}/daemon.json:/etc/docker/daemon.json:ro
       - reset-apps:/var/sota/reset-apps
 
@@ -31,6 +32,7 @@ services:
       - ${SRC_DIR}:${SRC_DIR}
       - ${BIN_DIR}:${SRC_DIR}/bin
       - docker-runtime:/var/run/docker
+      - docker-data:/var/lib/docker
       - reset-apps:/var/sota/reset-apps
     working_dir: ${SRC_DIR}
     depends_on:
@@ -45,5 +47,6 @@ services:
       - STOREROOT=/var/sota/reset-apps
 
 volumes:
+  docker-data:
   docker-runtime:
   reset-apps:

--- a/test/fixtures/layers_meta.go
+++ b/test/fixtures/layers_meta.go
@@ -1,0 +1,40 @@
+package fixtures
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func GenerateLayersMetaFile(t *testing.T, appsRootDir string) string {
+	tmpDir := t.TempDir()
+	layerSizesFile := filepath.Join(tmpDir, "layers_meta.json")
+	c := exec.Command("python", os.Getenv("LAYERS_SIZE_SCRIPT"), "--apps-root",
+		appsRootDir, "-o", layerSizesFile)
+	output, err := c.CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to run the script that calculates app layer sizes: %s\n", output)
+	}
+	b, err := os.ReadFile(layerSizesFile)
+	if err != nil {
+		t.Fatalf("failed to read file witj app layer sizes: %s\n", err)
+	}
+	var ls map[string]interface{}
+	if err := json.Unmarshal(b, &ls); err != nil {
+		t.Fatalf("failed to unmarshal app layer sizes: %s\n", err)
+	}
+	lsPerArch := map[string]interface{}{
+		"amd64": ls,
+	}
+	b, err = json.Marshal(lsPerArch)
+	if err != nil {
+		t.Fatalf("failed to marshal app layer sizes per architecure: %s\n", err)
+	}
+	layersMetaFile := filepath.Join(tmpDir, "layers_meta_per_arch.json")
+	if err := os.WriteFile(layersMetaFile, b, 0x644); err != nil {
+		t.Fatalf("failed to write file: %s\n", err)
+	}
+	return layersMetaFile
+}

--- a/test/fixtures/layers_meta.go
+++ b/test/fixtures/layers_meta.go
@@ -14,27 +14,15 @@ func GenerateLayersMetaFile(t *testing.T, appsRootDir string) string {
 	c := exec.Command("python", os.Getenv("LAYERS_SIZE_SCRIPT"), "--apps-root",
 		appsRootDir, "-o", layerSizesFile)
 	output, err := c.CombinedOutput()
-	if err != nil {
-		t.Fatalf("failed to run the script that calculates app layer sizes: %s\n", output)
-	}
+	checkf(t, err, "failed to run command to gather app layer sizes: %s", string(output))
 	b, err := os.ReadFile(layerSizesFile)
-	if err != nil {
-		t.Fatalf("failed to read file witj app layer sizes: %s\n", err)
-	}
+	check(t, err)
 	var ls map[string]interface{}
-	if err := json.Unmarshal(b, &ls); err != nil {
-		t.Fatalf("failed to unmarshal app layer sizes: %s\n", err)
-	}
-	lsPerArch := map[string]interface{}{
-		"amd64": ls,
-	}
+	check(t, json.Unmarshal(b, &ls))
+	lsPerArch := map[string]interface{}{"amd64": ls}
 	b, err = json.Marshal(lsPerArch)
-	if err != nil {
-		t.Fatalf("failed to marshal app layer sizes per architecure: %s\n", err)
-	}
+	check(t, err)
 	layersMetaFile := filepath.Join(tmpDir, "layers_meta_per_arch.json")
-	if err := os.WriteFile(layersMetaFile, b, 0x644); err != nil {
-		t.Fatalf("failed to write file: %s\n", err)
-	}
+	check(t, os.WriteFile(layersMetaFile, b, 0x644))
 	return layersMetaFile
 }

--- a/test/integration/edge_cases_test.go
+++ b/test/integration/edge_cases_test.go
@@ -51,7 +51,7 @@ services:
 	app := f.NewApp(t, appComposeDef)
 	app.Publish(t)
 
-	app02 := f.NewApp(t, appComposeDef02, f.WithAppName(app.Name))
+	app02 := f.NewApp(t, appComposeDef02, app.Name)
 	app02.Publish(t)
 
 	app.Pull(t)

--- a/test/integration/smoke_test.go
+++ b/test/integration/smoke_test.go
@@ -1,7 +1,8 @@
 package e2e_tests
 
 import (
-	"github.com/foundriesio/composeapp/test/fixtures"
+	f "github.com/foundriesio/composeapp/test/fixtures"
+	"path/filepath"
 	"testing"
 )
 
@@ -12,9 +13,11 @@ services:
     image: ghcr.io/foundriesio/busybox:1.36
     command: sh -c "while true; do sleep 60; done"
 `
+	app := f.NewApp(t, appComposeDef)
+	layersMetaFile := f.GenerateLayersMetaFile(t, filepath.Dir(app.Dir))
+
 	smokeTest := func(registry string, layersManifest bool) {
-		app := fixtures.NewApp(t, appComposeDef, fixtures.WithRegistry(registry))
-		app.Publish(t, !layersManifest)
+		app.Publish(t, f.WithRegistry(registry), f.WithLayersManifest(layersManifest), f.WithLayersMeta(layersMetaFile))
 
 		app.Pull(t)
 		defer app.Remove(t)


### PR DESCRIPTION
Extend the test environment with functionality to generate metadata about image layers (size of extracted layers/blobs) and use the generated layer metadata in the `compose publish` testing. It helps us to cover the real-life use-case that occurs in the factory CI.