### PR TITLE
Switch to distribution 2.8.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/foundriesio/composeapp
 
 go 1.22
 
-replace github.com/docker/distribution => github.com/docker/distribution v2.7.1+incompatible
-
 require (
 	github.com/compose-spec/compose-go v1.20.2
 	github.com/containerd/containerd v1.7.15

--- a/go.sum
+++ b/go.sum
@@ -36,8 +36,8 @@ github.com/distribution/reference v0.6.0 h1:0IXCQ5g4/QMHHkarYzh5l+u8T3t73zM5Qvfr
 github.com/distribution/reference v0.6.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/docker/cli v25.0.3+incompatible h1:KLeNs7zws74oFuVhgZQ5ONGZiXUUdgsdy6/EsX/6284=
 github.com/docker/cli v25.0.3+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
-github.com/docker/distribution v2.7.1+incompatible h1:a5mlkVzth6W5A4fOsS3D2EO5BUmsJpcB+cRlLU7cSug=
-github.com/docker/distribution v2.7.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
+github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
+github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
 github.com/docker/docker v25.0.3+incompatible h1:D5fy/lYmY7bvZa0XTZ5/UJPljor41F+vdyJG5luQLfQ=
 github.com/docker/docker v25.0.3+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.7.0 h1:xtCHsjxogADNZcdv1pKUHXryefjlVRqWqIhk/uXJp0A=

--- a/pkg/compose/layers.go
+++ b/pkg/compose/layers.go
@@ -288,7 +288,7 @@ func PostAppLayersManifests(ctx context.Context, appRef string, layers map[strin
 			fmt.Printf("  |-> skipping layer manifest publishing for dryrun\n")
 		} else {
 			fmt.Printf("  |-> posting a layer manifest for architecture: %s...", arch)
-			digest, err := manSvc.Put(ctx, manifest)
+			digest, err := manSvc.Put(ctx, manifest, distribution.WithTag("layers-"+arch+(desc.Digest.Hex())[:7]))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Adjust the publish implementation so there are no any errors if the newer version (2.8.1) of the distribution is used as dependency.