### PR TITLE
show: Commands to output app manifest and compose

### DIFF
--- a/cmd/composectl/cmd/compose.go
+++ b/cmd/composectl/cmd/compose.go
@@ -1,0 +1,61 @@
+package composectl
+
+import (
+	"fmt"
+	"github.com/containerd/containerd/platforms"
+	"github.com/foundriesio/composeapp/pkg/compose"
+	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
+	"github.com/spf13/cobra"
+	"path"
+)
+
+var (
+	composeCmd = &cobra.Command{
+		Use:   "compose <ref>",
+		Short: "compose <ref>",
+		Long:  ``,
+		Args:  cobra.ExactArgs(1),
+	}
+)
+
+type (
+	composeOptions struct {
+		SrcStorePath *string
+		Locally      *bool
+	}
+)
+
+func init() {
+	opts := composeOptions{}
+
+	opts.SrcStorePath = composeCmd.Flags().StringP("source-store-path", "l", "",
+		"A path to the source store root directory")
+	opts.Locally = composeCmd.Flags().BoolP("local", "", false,
+		"Print compose config/file of app stored locally")
+	composeCmd.Run = func(cmd *cobra.Command, args []string) {
+		doOutputComposeFile(cmd, args, &opts)
+	}
+
+	showCmd.AddCommand(composeCmd)
+}
+
+func doOutputComposeFile(cmd *cobra.Command, args []string, opts *composeOptions) {
+	if *opts.Locally && len(*opts.SrcStorePath) == 0 {
+		opts.SrcStorePath = &config.StoreRoot
+	}
+	var blobProvider compose.BlobProvider
+	if len(*opts.SrcStorePath) > 0 {
+		blobProvider = compose.NewStoreBlobProvider(path.Join(*opts.SrcStorePath, "blobs", "sha256"))
+	} else {
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
+		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		blobProvider = compose.NewRemoteBlobProvider(resolver)
+	}
+	app, _, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), blobProvider, platforms.OnlyStrict(config.Platform), args[0])
+	DieNotNil(err)
+	composeProject, err := app.GetCompose(cmd.Context(), blobProvider)
+	DieNotNil(err)
+	b, err := composeProject.MarshalYAML()
+	DieNotNil(err)
+	fmt.Printf("%s", string(b))
+}

--- a/cmd/composectl/cmd/manifest.go
+++ b/cmd/composectl/cmd/manifest.go
@@ -1,0 +1,56 @@
+package composectl
+
+import (
+	"fmt"
+	"github.com/foundriesio/composeapp/pkg/compose"
+	"github.com/foundriesio/composeapp/pkg/compose/v1"
+	"github.com/spf13/cobra"
+	"path"
+)
+
+var (
+	manifestCmd = &cobra.Command{
+		Use:   "manifest <ref>",
+		Short: "manifest <ref>",
+		Long:  ``,
+		Args:  cobra.ExactArgs(1),
+	}
+)
+
+type (
+	manifestOptions struct {
+		SrcStorePath *string
+		Locally      *bool
+	}
+)
+
+func init() {
+	opts := manifestOptions{}
+
+	opts.SrcStorePath = manifestCmd.Flags().StringP("source-store-path", "l", "",
+		"A path to the source store root directory")
+	opts.Locally = manifestCmd.Flags().BoolP("local", "", false,
+		"Print manifest of app stored locally")
+	manifestCmd.Run = func(cmd *cobra.Command, args []string) {
+		doOutputManifest(cmd, args, &opts)
+	}
+
+	showCmd.AddCommand(manifestCmd)
+}
+
+func doOutputManifest(cmd *cobra.Command, args []string, opts *manifestOptions) {
+	if *opts.Locally && len(*opts.SrcStorePath) == 0 {
+		opts.SrcStorePath = &config.StoreRoot
+	}
+	var blobProvider compose.BlobProvider
+	if len(*opts.SrcStorePath) > 0 {
+		blobProvider = compose.NewStoreBlobProvider(path.Join(*opts.SrcStorePath, "blobs", "sha256"))
+	} else {
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
+		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		blobProvider = compose.NewRemoteBlobProvider(resolver)
+	}
+	b, err := compose.ReadBlobWithReadLimit(cmd.Context(), blobProvider, args[0], v1.AppManifestMaxSize)
+	DieNotNil(err)
+	fmt.Printf("%s\n", string(b))
+}

--- a/cmd/composectl/cmd/show.go
+++ b/cmd/composectl/cmd/show.go
@@ -1,0 +1,14 @@
+package composectl
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var showCmd = &cobra.Command{
+	Use:   "show",
+	Short: "output app manifest or compose file",
+}
+
+func init() {
+	rootCmd.AddCommand(showCmd)
+}

--- a/pkg/compose/app.go
+++ b/pkg/compose/app.go
@@ -3,6 +3,7 @@ package compose
 import (
 	"context"
 	"fmt"
+	composetypes "github.com/compose-spec/compose-go/types"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/reference"
 	"github.com/opencontainers/go-digest"
@@ -26,6 +27,7 @@ type (
 		HasLayersMeta(arch string) bool
 		GetBlobRuntimeSize(desc *ocispec.Descriptor, arch string, blockSize int64) int64
 		GetComposeRoot() *TreeNode
+		GetCompose(ctx context.Context, provider BlobProvider) (*composetypes.Project, error)
 	}
 	AppLoader interface {
 		LoadAppTree(context.Context, BlobProvider, platforms.MatchComparer, string) (App, *AppTree, error)

--- a/pkg/compose/v1/app.go
+++ b/pkg/compose/v1/app.go
@@ -165,6 +165,11 @@ func (a *appCtx) GetComposeRoot() *compose.TreeNode {
 	return nil
 }
 
+func (a *appCtx) GetCompose(ctx context.Context, provider compose.BlobProvider) (project *composetypes.Project, err error) {
+	project, _, err = readAndLoadComposeProject(ctx, provider, a)
+	return
+}
+
 func ReadAppManifest(ctx context.Context, provider compose.BlobProvider, ref string) (*appCtx, *ocispec.Descriptor, error) {
 	appRef, err := parseAndCheckAppRef(ref)
 	if err != nil {


### PR DESCRIPTION
Add a new command `show` with two sub-commands to print App manifest and compose file/project.