### PR TITLE
Improve app bundle integrity check

### DIFF
--- a/cmd/composectl/cmd/ps.go
+++ b/cmd/composectl/cmd/ps.go
@@ -95,6 +95,8 @@ func getAppsStatus(ctx context.Context, appRefs []string, runningApps map[string
 				URI:   appRef,
 				Name:  app.Name(),
 				State: "not running",
+				// app is present in the store because its tree was loaded successfully prior to executing this check
+				InStore: true,
 			}
 			continue
 		}

--- a/pkg/compose/app.go
+++ b/pkg/compose/app.go
@@ -20,15 +20,16 @@ type (
 		Digest digest.Digest
 	}
 
-	AppTree TreeNode
-	App     interface {
+	AppBundleErrs map[string]string
+	AppTree       TreeNode
+	App           interface {
 		Name() string
 		Ref() *AppRef
 		HasLayersMeta(arch string) bool
 		GetBlobRuntimeSize(desc *ocispec.Descriptor, arch string, blockSize int64) int64
 		GetComposeRoot() *TreeNode
 		GetCompose(ctx context.Context, provider BlobProvider) (*composetypes.Project, error)
-		CheckComposeInstallation(ctx context.Context, provider BlobProvider, installationRootDir string) (map[string]error, error)
+		CheckComposeInstallation(ctx context.Context, provider BlobProvider, installationRootDir string) (AppBundleErrs, error)
 	}
 	AppLoader interface {
 		LoadAppTree(context.Context, BlobProvider, platforms.MatchComparer, string) (App, *AppTree, error)


### PR DESCRIPTION
- Unify and simplify implementation of the app installation verification.
- Optionally, check whether an app is installed as part of the command verifying if an app is running.