### PR TITLE
app: Skip app integrity check if pulled by skopeo

### DIFF
--- a/cmd/composectl/cmd/ps.go
+++ b/cmd/composectl/cmd/ps.go
@@ -83,10 +83,11 @@ func psApps(cmd *cobra.Command, args []string, opts *psOptions) {
 }
 
 func getAppsStatus(ctx context.Context, appRefs []string, runningApps map[string]*App, checkInstall bool) map[string]*App {
-	storeBlobProvider := compose.NewStoreBlobProvider(path.Join(config.StoreRoot, "blobs", "sha256"))
+	store, err := v1.NewAppStore(config.StoreRoot, config.Platform)
+	DieNotNil(err)
 	apps := map[string]compose.App{}
 	for _, appRef := range appRefs {
-		app, _, err := v1.NewAppLoader().LoadAppTree(ctx, storeBlobProvider, platforms.OnlyStrict(config.Platform), appRef)
+		app, _, err := v1.NewAppLoader().LoadAppTree(ctx, store, platforms.OnlyStrict(config.Platform), appRef)
 		DieNotNil(err)
 		apps[appRef] = app
 	}
@@ -188,7 +189,7 @@ func getAppsStatus(ctx context.Context, appRefs []string, runningApps map[string
 	}
 
 	if checkInstall {
-		checkInstallResult, err := checkIfInstalled(ctx, appRefs, config.StoreRoot, config.DockerHost)
+		checkInstallResult, err := checkIfInstalled(ctx, appRefs, store, config.DockerHost)
 		DieNotNil(err)
 		for app, ir := range checkInstallResult {
 			appStatuses[app].BundleErrors = ir.BundleErrors

--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -39,7 +39,12 @@ func pullApps(cmd *cobra.Command, args []string) {
 	} else {
 		fmt.Printf("Pulling %s to %s\n", args[0], config.StoreRoot)
 	}
-	cr, ui, apps := checkApps(cmd.Context(), args, *pullUsageWatermark, *pullSrcStorePath, false, true)
+
+	srcBlobProvider, cs, err := getAppStoreAndDstBlobProvider(*pullSrcStorePath, false)
+	DieNotNil(err)
+
+	cr, ui, apps := checkApps(cmd.Context(), args, cs, srcBlobProvider, *pullUsageWatermark,
+		*pullSrcStorePath, false, true)
 	if len(cr.MissingBlobs) > 0 {
 		ui.Print()
 		if ui.Required > ui.Available {
@@ -74,8 +79,7 @@ func pullApps(cmd *cobra.Command, args []string) {
 			fmt.Println("ok")
 		}
 	}
-	cs, err := v1.NewAppStore(config.StoreRoot, config.Platform)
-	DieNotNil(err)
+
 	for _, app := range apps {
 		err = v1.MakeAkliteHappy(cmd.Context(), cs, app, platforms.OnlyStrict(config.Platform))
 		DieNotNil(err)

--- a/pkg/compose/app.go
+++ b/pkg/compose/app.go
@@ -36,6 +36,21 @@ type (
 	}
 )
 
+const (
+	ctxKeyAppRef ctxKeyType = "app:ref"
+)
+
+func WithAppRef(ctx context.Context, ref *AppRef) context.Context {
+	return context.WithValue(ctx, ctxKeyAppRef, ref)
+}
+
+func GetAppRef(ctx context.Context) *AppRef {
+	if appRef, ok := ctx.Value(ctxKeyAppRef).(*AppRef); ok {
+		return appRef
+	}
+	return nil
+}
+
 func ParseAppRef(ref string) (*AppRef, error) {
 	s, err := reference.Parse(ref)
 	if err != nil {

--- a/pkg/compose/v1/app_store.go
+++ b/pkg/compose/v1/app_store.go
@@ -116,10 +116,9 @@ func (s *appStore) Prune(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	blobProvider := compose.NewStoreBlobProvider(s.blobsRoot)
 	referencedBlobs := map[string]bool{}
 	for _, a := range apps {
-		_, tree, err := NewAppLoader().LoadAppTree(ctx, blobProvider, platforms.OnlyStrict(s.platform), a.String())
+		_, tree, err := NewAppLoader().LoadAppTree(ctx, s, platforms.OnlyStrict(s.platform), a.String())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/compose/v1/install.go
+++ b/pkg/compose/v1/install.go
@@ -89,7 +89,7 @@ func installCompose(ctx context.Context, app compose.App, provider compose.BlobP
 		return err
 	}
 	appContext := app.(*appCtx)
-	rc, err := provider.GetReadCloser(compose.WithBlobType(WithAppRef(ctx, &appContext.AppRef), compose.BlobTypeAppBundle),
+	rc, err := provider.GetReadCloser(compose.WithBlobType(compose.WithAppRef(ctx, &appContext.AppRef), compose.BlobTypeAppBundle),
 		compose.WithExpectedDigest(composeDesc.Digest), compose.WithExpectedSize(composeDesc.Size))
 	if err != nil {
 		return err

--- a/test/compose/Dockerfile
+++ b/test/compose/Dockerfile
@@ -3,7 +3,7 @@ FROM golang:1.22-alpine
 ARG REG_CERT=test/compose/registry/certs/registry.crt
 ARG SRC_DIR=$PWD
 
-RUN apk add make curl docker docker-compose git python3 py3-requests py3-expandvars py3-yaml
+RUN apk add make curl docker docker-compose git python3 py3-requests py3-expandvars py3-yaml skopeo
 
 # fetch ci-scripts, needed for calculating sizes of extacted app layers
 RUN git clone https://github.com/foundriesio/ci-scripts.git /ci-scripts

--- a/test/fixtures/preload-images.sh
+++ b/test/fixtures/preload-images.sh
@@ -6,7 +6,7 @@ IMAGE_NAME="factory/runner-image"
 IMAGE_TAG="v0.1"
 IMAGE_URI="${REGISTRY_URL}/${IMAGE_NAME}:${IMAGE_TAG}"
 
-SRC_IMAGE="ghcr.io/foundriesio/busybox:1.36"
+SRC_IMAGE="ghcr.io/foundriesio/busybox:1.36-multiarch"
 
 # Check if the image exists in the registry
 check_image() {
@@ -21,11 +21,7 @@ check_image() {
 }
 
 if ! check_image; then
-    docker pull ${SRC_IMAGE}
-    docker tag ${SRC_IMAGE} ${IMAGE_URI}
-    docker push ${IMAGE_URI}
-    docker image rm ${SRC_IMAGE}
-    docker image rm ${IMAGE_URI}
+    skopeo copy --insecure-policy --all docker://${SRC_IMAGE} docker://${IMAGE_URI}
 else
     echo "Image ${IMAGE_URI} exists in the registry."
 fi

--- a/test/integration/edge_cases_test.go
+++ b/test/integration/edge_cases_test.go
@@ -137,6 +137,7 @@ services:
 
 	app.PullAppImagesWithSkopeo(t)
 	defer app.Remove(t)
+	app.CheckFetched(t)
 
 	app.Install(t)
 	defer app.Uninstall(t)

--- a/test/integration/edge_cases_test.go
+++ b/test/integration/edge_cases_test.go
@@ -119,3 +119,29 @@ services:
 	// Install app again, so it can be stopped without any error
 	app.Install(t)
 }
+
+func TestAppRunIfPulledBySkopeo(t *testing.T) {
+	appComposeDef := `
+services:
+  srvs-01:
+    image: registry:5000/factory/runner-image:v0.1
+    command: sh -c "while true; do sleep 60; done"
+    ports:
+    - 8080:80
+  srvs-02:
+    image: registry:5000/factory/runner-image:v0.1
+    command: sh -c "while true; do sleep 60; done"
+`
+	app := f.NewApp(t, appComposeDef)
+	app.Publish(t)
+
+	app.PullAppImagesWithSkopeo(t)
+	defer app.Remove(t)
+
+	app.Install(t)
+	defer app.Uninstall(t)
+
+	app.Run(t)
+	app.CheckRunning(t)
+	defer app.Stop(t)
+}


### PR DESCRIPTION
Make `composectl` work if app is pulled by "aklite+skopeo".

1. Don't require all app blobs to install and start app if app is pulled by "aklite+skopeo". Require only those blobs that are mandatory to install and start app.

2. Don't require all app blobs during checking app "locally" in fully offline mode.

3. Skip app integrity check if app blobs are pulled by "aklite+skopeo".

3. Added a test to verify the aforementioned use-case.