### PR TITLE
app_store: Avoid app bundle removal if blob store is pruned

### DIFF
--- a/pkg/compose/v1/app_store.go
+++ b/pkg/compose/v1/app_store.go
@@ -265,7 +265,7 @@ func MakeAkliteHappy(ctx context.Context, store compose.AppStore, app compose.Ap
 			fmt.Printf("Failed to delete the current app manifest file: %s\n", err.Error())
 		}
 	}
-	if err := syscall.Symlink(blobPath, manifestLink); err != nil {
+	if err := syscall.Link(blobPath, manifestLink); err != nil {
 		return err
 	}
 
@@ -285,7 +285,7 @@ func MakeAkliteHappy(ctx context.Context, store compose.AppStore, app compose.Ap
 		}
 	}
 	if !appBundleLinkExists {
-		if err := syscall.Symlink(path.Join(storeV1.root, "blobs/sha256", appBundleDesc.Digest.Encoded()), appBundleLink); err != nil {
+		if err := syscall.Link(path.Join(storeV1.root, "blobs/sha256", appBundleDesc.Digest.Encoded()), appBundleLink); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Use hard links instead of symlinks for an app bundle archive and app manifest in the app directory of an overall app store.

Using symlinks leads to removal of these two artifacts if downgrade or rollback to LmP version <=93 occurs. The previous aklite versions do not expect these two blobs in the blob store, they expect them in the app directory of the store, so the prune operation removes them from the blob store, and, as the result, the symlinks defined in the app directory become invalid. It makes aklite thinks that app is not fully fetched and starts the "sync" update which never succeeds, so aklite ends up in doing eternal "sync" updates.

Replacing the symlinks with hard links fixes the issue since the blobs are not removed because they have two links/references, one in the blobs part and the second one in the app directory. Removing one of these hard links does not lead to the blob removal.