### PR TITLE
app: Increase max size of compose file

### DIFF
--- a/pkg/compose/v1/app.go
+++ b/pkg/compose/v1/app.go
@@ -47,8 +47,8 @@ type (
 const (
 	AppManifestMediaType   = "application/vnd.oci.image.manifest.v1+json"
 	AppManifestMaxSize     = 50 * 1024
-	AppBundleFileMaxSize   = 1024 * 1024 * 1024
-	AppComposeMaxSize      = 100 * 1024
+	AppComposeMaxSize      = 1024 * 1024
+	AppBundleFileMaxSize   = 1024*1024*1024 - AppComposeMaxSize
 	AppBundleMaxSize       = AppComposeMaxSize + AppBundleFileMaxSize
 	AppLayerMediaType      = "application/octet-stream"
 	AppLayersMetaVersion   = "v1"


### PR DESCRIPTION
Increase the maximum allowed size of a compose file up to 1MB.