### PR TITLE
publish: Enforce media type of app bundle layer

### DIFF
--- a/pkg/compose/v1/publish.go
+++ b/pkg/compose/v1/publish.go
@@ -187,10 +187,13 @@ func createAndPublishApp(ctx context.Context,
 	}
 
 	blobStore := repo.Blobs(ctx)
-	desc, err := blobStore.Put(ctx, "application/tar+gzip", buff)
+	desc, err := blobStore.Put(ctx, AppLayerMediaType, buff)
 	if err != nil {
 		return "", err
 	}
+	// enforce App's layer media type to make sure it is the same regardless container registry service
+	// (some container registries changes the media type specified by a client)
+	desc.MediaType = AppLayerMediaType
 	fmt.Println("  |-> app blob: ", desc.Digest.String())
 
 	if appContentHashes != nil && len(appContentHashes) > 0 {


### PR DESCRIPTION
It turned out that some of the 3rd party registries changes the media type of a blob/layer specified by a client. Therefore, we need explicitly set the media type to `application/octet-stream` after the app blob has been published before creating an app's manifest. Using media type other than `application/octet-stream` breaks the older versions of `aklite` and `composectl` that explicitly expects the given media type.