### PR TITLE
prune: Use correct blob provider

### DIFF
--- a/pkg/compose/v1/app_store.go
+++ b/pkg/compose/v1/app_store.go
@@ -114,10 +114,9 @@ func (s *appStore) Prune(ctx context.Context) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	blobProvider := compose.NewStoreBlobProvider(s.blobsRoot)
 	referencedBlobs := map[string]bool{}
 	for _, a := range apps {
-		_, tree, err := NewAppLoader().LoadAppTree(ctx, blobProvider, platforms.OnlyStrict(s.platform), a.String())
+		_, tree, err := NewAppLoader().LoadAppTree(ctx, s, platforms.OnlyStrict(s.platform), a.String())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The app store's blob provider should be used for the app pruning, otherwise app pulled by `skopeo` won't be loadable.