### PR TITLE
ps: Don't print info about ext images if json output

### DIFF
--- a/cmd/composectl/cmd/uninstall.go
+++ b/cmd/composectl/cmd/uninstall.go
@@ -35,7 +35,7 @@ func init() {
 }
 
 func uninstallApps(cmd *cobra.Command, args []string, opts *uninstallOptions) {
-	apps := getAllAppStatuses(cmd.Context())
+	apps := getAllAppStatuses(cmd.Context(), false)
 	for _, app := range args {
 		if _, ok := apps[app]; ok {
 			DieNotNil(fmt.Errorf("cannot uninstall running app: %s", app))


### PR DESCRIPTION
Don't print log message about found external image or app if a `json` output format is specified.