### PR TITLE
auth: Add connection timeout for auth requests

### DIFF
--- a/cmd/composectl/cmd/check.go
+++ b/cmd/composectl/cmd/check.go
@@ -321,8 +321,8 @@ func getAppStoreAndDstBlobProvider(srcStorePath string, local bool) (srcBlobProv
 		// to Registry. Requires app manifest and app archive presence in the local store, otherwise fails.
 		srcBlobProvider = store
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 		srcBlobProvider = compose.NewRemoteBlobProvider(resolver)
 	}
 	return

--- a/cmd/composectl/cmd/compose.go
+++ b/cmd/composectl/cmd/compose.go
@@ -47,8 +47,8 @@ func doOutputComposeFile(cmd *cobra.Command, args []string, opts *composeOptions
 	if len(*opts.SrcStorePath) > 0 {
 		blobProvider = compose.NewStoreBlobProvider(path.Join(*opts.SrcStorePath, "blobs", "sha256"))
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 		blobProvider = compose.NewRemoteBlobProvider(resolver)
 	}
 	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), blobProvider, platforms.OnlyStrict(config.Platform), args[0])

--- a/cmd/composectl/cmd/config.go
+++ b/cmd/composectl/cmd/config.go
@@ -3,15 +3,16 @@ package composectl
 import (
 	"github.com/docker/cli/cli/config/configfile"
 	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"time"
 )
 
 type Config struct {
-	StoreRoot   string
-	ComposeRoot string
-	DockerCfg   *configfile.ConfigFile
-	DockerHost  string
-	Platform    specs.Platform
-	ConnectTime int
+	StoreRoot      string
+	ComposeRoot    string
+	DockerCfg      *configfile.ConfigFile
+	DockerHost     string
+	Platform       specs.Platform
+	ConnectTimeout time.Duration
 }
 
 var (

--- a/cmd/composectl/cmd/inspect.go
+++ b/cmd/composectl/cmd/inspect.go
@@ -23,8 +23,8 @@ var inspectCmd = &cobra.Command{
 func inspectApp(cmd *cobra.Command, args []string) {
 	appRef := args[0]
 
-	authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-	resolver := compose.NewResolver(authorizer, config.ConnectTime)
+	authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+	resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 	fmt.Printf("Inspecting App %s...", appRef)
 	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), compose.NewRemoteBlobProvider(resolver), platforms.All, appRef)
 	DieNotNil(err)

--- a/cmd/composectl/cmd/manifest.go
+++ b/cmd/composectl/cmd/manifest.go
@@ -46,8 +46,8 @@ func doOutputManifest(cmd *cobra.Command, args []string, opts *manifestOptions) 
 	if len(*opts.SrcStorePath) > 0 {
 		blobProvider = compose.NewStoreBlobProvider(path.Join(*opts.SrcStorePath, "blobs", "sha256"))
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 		blobProvider = compose.NewRemoteBlobProvider(resolver)
 	}
 	b, err := compose.ReadBlobWithReadLimit(cmd.Context(), blobProvider, args[0], v1.AppManifestMaxSize)

--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -61,8 +61,8 @@ func pullApps(cmd *cobra.Command, args []string) {
 		// TODO:  move to a separate function:
 		//  1) Copy in multiple goroutines/workers (configurable)
 		//  2) Generic status reporting mechanism
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg)
-		resolver := compose.NewResolver(authorizer, config.ConnectTime)
+		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 
 		ls, err := local.NewStore(config.StoreRoot)
 		DieNotNil(err)

--- a/cmd/composectl/cmd/root.go
+++ b/cmd/composectl/cmd/root.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"path/filepath"
 	"strconv"
+	"time"
 )
 
 const (
@@ -82,7 +83,7 @@ func init() {
 		composeRoot = path.Join(homeDir, ".composeapps/projects")
 	}
 	var err error
-	defConnectTimeoutValue := 30
+	defConnectTimeoutValue := 30 // The default TCP connection timeout in seconds
 	if len(defConnectTimeout) > 0 {
 		fmt.Println(defConnectTimeout)
 		defConnectTimeoutValue, err = strconv.Atoi(defConnectTimeout)
@@ -93,7 +94,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&config.ComposeRoot, "compose", "i", composeRoot, "compose projects root path")
 	rootCmd.PersistentFlags().StringVarP(&arch, "arch", "a", "", "architecture of app/images to pull")
 	rootCmd.PersistentFlags().StringVarP(&dockerHost, "host", "H", "", "path to the socket on which the Docker daemon listens")
-	rootCmd.PersistentFlags().IntVarP(&connectTimeout, "connect-timeout", "", defConnectTimeoutValue, "timeout for connecting to a container registry service")
+	rootCmd.PersistentFlags().IntVarP(&connectTimeout, "connect-timeout", "", defConnectTimeoutValue,
+		"timeout in seconds for establishing a connection to a container registry and an authentication service")
 	rootCmd.PersistentFlags().BoolVarP(&showConfigFile, "show-config", "C", false, "print paths of the applied config files")
 	rootCmd.AddCommand(versionCmd)
 }
@@ -153,5 +155,5 @@ func initConfig() {
 	if len(arch) > 0 {
 		config.Platform.Architecture = arch
 	}
-	config.ConnectTime = connectTimeout
+	config.ConnectTimeout = time.Duration(connectTimeout) * time.Second
 }

--- a/pkg/compose/auth.go
+++ b/pkg/compose/auth.go
@@ -4,10 +4,22 @@ import (
 	"fmt"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/cli/cli/config/configfile"
+	"net"
+	"net/http"
+	"time"
 )
 
-func NewRegistryAuthorizer(cfg *configfile.ConfigFile) docker.Authorizer {
-	return docker.NewDockerAuthorizer(docker.WithAuthCreds(getAuthCreds(cfg)))
+func NewRegistryAuthorizer(cfg *configfile.ConfigFile, connectTimeout time.Duration) docker.Authorizer {
+	return docker.NewDockerAuthorizer(
+		docker.WithAuthCreds(getAuthCreds(cfg)),
+		docker.WithAuthClient(&http.Client{
+			Transport: &http.Transport{
+				DialContext: (&net.Dialer{
+					Timeout: connectTimeout,
+				}).DialContext,
+			},
+		}),
+	)
 }
 
 type (

--- a/pkg/compose/resolver.go
+++ b/pkg/compose/resolver.go
@@ -8,13 +8,13 @@ import (
 	"time"
 )
 
-func NewResolver(authorizer docker.Authorizer, connectTimeout int) remotes.Resolver {
+func NewResolver(authorizer docker.Authorizer, connectTimeout time.Duration) remotes.Resolver {
 	ropts := []docker.RegistryOpt{
 		docker.WithAuthorizer(authorizer),
 		docker.WithClient(&http.Client{
 			Transport: &http.Transport{
 				DialContext: (&net.Dialer{
-					Timeout: time.Duration(connectTimeout) * time.Second,
+					Timeout: connectTimeout,
 				}).DialContext,
 			},
 		}),


### PR DESCRIPTION
Add a timeout for setting TLS/TCP connection to an auth server that occurs at an initial phase of transferring data from a container registry.