### PR TITLE
Check compose if no indexes

### DIFF
--- a/pkg/compose/v1/app.go
+++ b/pkg/compose/v1/app.go
@@ -43,6 +43,12 @@ type (
 	}
 
 	appLoader struct{}
+
+	fileInfo struct {
+		name   string
+		size   int64
+		digest digest.Digest
+	}
 )
 
 const (
@@ -276,12 +282,12 @@ func (a *appCtx) CheckComposeInstallation(ctx context.Context, provider compose.
 	appIndex, errBundleIndx := a.getAppBundleIndex(ctx, provider)
 	if errBundleIndx != nil {
 		if errBundleIndx == ErrAppHasNoIndex {
-			// App manifest does not include its bundle index, hence skip the bundle integrity checking
-			return nil, nil
+			return a.checkAppBundleInstallation(ctx, provider, installationRootDir)
 		} else {
 			return nil, errBundleIndx
 		}
 	}
+
 	bundleErrMap := compose.AppBundleErrs{}
 	for filePath, fileDigest := range appIndex {
 		f, err := os.Open(path.Join(installationRootDir, filePath))
@@ -296,6 +302,46 @@ func (a *appCtx) CheckComposeInstallation(ctx context.Context, provider compose.
 		if _, err := io.ReadAll(r); err != nil {
 			bundleErrMap[filePath] = err.Error()
 		}
+	}
+	if len(bundleErrMap) > 0 {
+		bundleErrs = bundleErrMap
+	}
+	return
+}
+
+func (a *appCtx) checkAppBundleInstallation(ctx context.Context, provider compose.BlobProvider, installationRootDir string) (bundleErrs compose.AppBundleErrs, err error) {
+	appBundleDescriptor, err := a.GetComposeDescriptor()
+	if err != nil {
+		return nil, err
+	}
+	appBundleFiles, err := a.indexAppBundle(ctx, provider, appBundleDescriptor)
+	if err != nil {
+		return nil, err
+	}
+	bundleErrMap := compose.AppBundleErrs{}
+	for _, bundleFile := range appBundleFiles {
+		func() {
+			filePath := path.Join(installationRootDir, bundleFile.name)
+			f, err := os.Open(filePath)
+			if err != nil {
+				bundleErrMap[filePath] = err.Error()
+				return
+			}
+			defer f.Close()
+			r, err := compose.NewSecureReadCloser(f, compose.WithExpectedDigest(bundleFile.digest),
+				compose.WithExpectedSize(bundleFile.size))
+			if err != nil {
+				bundleErrMap[filePath] = err.Error()
+				return
+			}
+			defer r.Close()
+			// It produces ErrBlobSizeMismatch or ErrBlobDigestMismatch error if the file is bigger than expected
+			// or a hash mismatch is detected after reading all file data
+			_, err = io.ReadAll(r)
+			if err != nil {
+				bundleErrMap[filePath] = err.Error()
+			}
+		}()
 	}
 	if len(bundleErrMap) > 0 {
 		bundleErrs = bundleErrMap
@@ -331,6 +377,48 @@ func (a *appCtx) getAppBundleIndex(ctx context.Context, blobProvider compose.Blo
 		return nil, fmt.Errorf("failed to unmarshal app bundle index: %s", err.Error())
 	}
 	return appIndex, nil
+}
+
+func (a *appCtx) indexAppBundle(ctx context.Context, provider compose.BlobProvider, appArchiveDesc *ocispec.Descriptor) ([]fileInfo, error) {
+	srcReader, err := provider.GetReadCloser(compose.WithBlobType(compose.WithAppRef(ctx, &a.AppRef), compose.BlobTypeAppBundle),
+		compose.WithRef(a.GetBlobRef(appArchiveDesc.Digest)),
+		compose.WithExpectedDigest(appArchiveDesc.Digest), compose.WithExpectedSize(appArchiveDesc.Size))
+	if err != nil {
+		return nil, err
+	}
+	defer srcReader.Close()
+
+	r, err := archive.DecompressStream(srcReader)
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+	tr := tar.NewReader(r)
+
+	var bundleFiles []fileInfo
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break // End of archive
+		}
+		if err != nil {
+			return nil, err
+		}
+		if hdr.Typeflag != tar.TypeReg {
+			continue // Skip non-regular files
+		}
+		digester := digest.Canonical.Digester()
+		_, err = io.Copy(digester.Hash(), tr)
+		if err != nil {
+			return nil, err
+		}
+		bundleFiles = append(bundleFiles, fileInfo{
+			name:   hdr.Name,
+			size:   hdr.Size,
+			digest: digester.Digest(),
+		})
+	}
+	return bundleFiles, nil
 }
 
 func getChildByType(children []*compose.TreeNode, childType compose.BlobType) *compose.TreeNode {

--- a/pkg/compose/v1/publish.go
+++ b/pkg/compose/v1/publish.go
@@ -196,7 +196,7 @@ func createAndPublishApp(ctx context.Context,
 	desc.MediaType = AppLayerMediaType
 	fmt.Println("  |-> app blob: ", desc.Digest.String())
 
-	if appContentHashes != nil && len(appContentHashes) > 0 {
+	if os.Getenv("APP_BUNDLE_INDEX_OFF") != "1" && appContentHashes != nil && len(appContentHashes) > 0 {
 		if d, err := publishAppBundleIndexBlob(ctx, blobStore, appContentHashes); err == nil {
 			desc.Annotations = map[string]string{
 				AnnotationKeyAppBundleIndexDigest: d.Digest.String(),

--- a/test/fixtures/composectl_cmds.go
+++ b/test/fixtures/composectl_cmds.go
@@ -38,9 +38,10 @@ type (
 	}
 
 	PublishOpts struct {
-		PublishLayersManifest bool
-		PublishLayersMetaFile bool
-		Registry              string
+		PublishLayersManifest   bool
+		PublishLayersMetaFile   bool
+		Registry                string
+		PublishAppBundleIndexes bool
 	}
 )
 
@@ -55,6 +56,12 @@ func Checkf(t *testing.T, err error, format string, args ...any) {
 	t.Helper()
 	if err != nil {
 		t.Fatalf(format, args...)
+	}
+}
+
+func WithAppBundleIndexes(enableAppBundleIndexes bool) func(opts *PublishOpts) {
+	return func(opts *PublishOpts) {
+		opts.PublishAppBundleIndexes = enableAppBundleIndexes
 	}
 }
 
@@ -134,7 +141,7 @@ func (a *App) removeImages(t *testing.T) {
 
 func (a *App) Publish(t *testing.T, publishOpts ...func(*PublishOpts)) {
 	a.pullImages(t)
-	opts := PublishOpts{PublishLayersManifest: true, PublishLayersMetaFile: true}
+	opts := PublishOpts{PublishLayersManifest: true, PublishLayersMetaFile: true, PublishAppBundleIndexes: true}
 	for _, o := range publishOpts {
 		o(&opts)
 	}
@@ -158,6 +165,14 @@ func (a *App) Publish(t *testing.T, publishOpts ...func(*PublishOpts)) {
 			defer os.RemoveAll(layersMetaFile)
 			args = append(args, "--layers-meta", layersMetaFile)
 		}
+		if !opts.PublishAppBundleIndexes {
+			os.Setenv("APP_BUNDLE_INDEX_OFF", "1")
+		}
+		defer func() {
+			if !opts.PublishAppBundleIndexes {
+				os.Unsetenv("APP_BUNDLE_INDEX_OFF")
+			}
+		}()
 		runCmd(t, a.Dir, args...)
 		b, err := os.ReadFile(digestFile)
 		Check(t, err)


### PR DESCRIPTION
- When the published app lacks bundle indexes, fall back to indexing
  the bundle on the fly. This enables checking whether the app's
  compose project is installed and whether it is valid.

- This is also necessary to determine which version of the app is
  actually installed when multiple versions are fetched, since all
  versions share the same compose directory.

- Add an integration test to verify this behavior: when two versions
  of the same app are published without bundle indexes, ensure we
  correctly detect which version is installed and running.