### PR TITLE
Cleanups and improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.1.6
 
   test:
     name: Build and run all tests

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,24 @@
-run:
-  timeout: 2m
+version: "2"
 linters:
   enable:
-    - errcheck
-    - gosimple
-    - staticcheck
-    - unused
-    - gofmt
     - gocyclo
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gofmt
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/cmd/composectl/cmd/check.go
+++ b/cmd/composectl/cmd/check.go
@@ -84,7 +84,7 @@ func init() {
 }
 
 func checkAppsCmd(cmd *cobra.Command, args []string, opts *checkOptions) {
-	quietCheck := false
+	var quietCheck bool
 	if opts.Format == "json" {
 		quietCheck = true
 	}
@@ -184,9 +184,9 @@ func checkApps(ctx context.Context,
 		}
 	}
 	checkResult := &CheckAppResult{
-		MissingBlobs: status.FetchStatus.MissingBlobs,
+		MissingBlobs: status.MissingBlobs,
 	}
-	for _, bi := range status.FetchStatus.MissingBlobs {
+	for _, bi := range status.MissingBlobs {
 		if bi.State == compose.BlobFetching {
 			checkResult.TotalPullSize += bi.Descriptor.Size - bi.Fetched
 			checkResult.TotalStoreSize += compose.AlignToBlockSize(bi.Descriptor.Size-bi.Fetched, config.BlockSize)

--- a/cmd/composectl/cmd/update/fetch.go
+++ b/cmd/composectl/cmd/update/fetch.go
@@ -35,7 +35,7 @@ func fetchUpdateCmd(cmd *cobra.Command, args []string, opts *fetchOptions) {
 	updateCtl, err := update.GetCurrentUpdate(cfg)
 	ExitIfNotNil(err)
 
-	bar := progressbar.DefaultBytes(updateCtl.Status().TotalBlobDownloadSize)
+	bar := progressbar.DefaultBytes(updateCtl.Status().TotalBlobsBytes)
 
 	err = updateCtl.Fetch(cmd.Context(), update.WithFetchProgress(func(status *update.FetchProgress) {
 		if err := bar.Set64(status.Current); err != nil {

--- a/cmd/composectl/cmd/update/status.go
+++ b/cmd/composectl/cmd/update/status.go
@@ -3,6 +3,7 @@ package updatectl
 import (
 	"errors"
 	"fmt"
+
 	"github.com/foundriesio/composeapp/pkg/compose"
 	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
 	"github.com/foundriesio/composeapp/pkg/update"
@@ -55,9 +56,12 @@ func updateStatusCmd(cmd *cobra.Command, args []string, opts *statusOptions) {
 	}
 	cmd.Printf("Date: \t\t%s\n", u.CreationTime.String())
 	cmd.Printf("State: \t\t%s\n", u.State)
-	cmd.Printf("Progress: \t%d\n", u.Progress)
-	cmd.Printf("Download Size: \t%d\n", u.TotalBlobDownloadSize)
-	cmd.Printf("Blobs: \t\t%d\n", len(u.Blobs))
+	cmd.Printf("Fetch Size: \t%s\n", compose.FormatBytesInt64(u.TotalBlobsBytes))
+	cmd.Printf("Blobs Number: \t%d\n", len(u.Blobs))
+	cmd.Printf("Progress: \t%d%%\n", u.Progress)
+	cmd.Printf("Fetched Bytes: \t%s\n", compose.FormatBytesInt64(u.FetchedBytes))
+	cmd.Printf("Fetched Blobs: \t%d\n", u.FetchedBlobs)
+
 	cmd.Println("URIs:")
 	for _, appURI := range u.URIs {
 		cmd.Printf("\t\t%s\n", appURI)
@@ -69,7 +73,7 @@ func updateStatusCmd(cmd *cobra.Command, args []string, opts *statusOptions) {
 
 		fmt.Println()
 		yesno := map[bool]string{false: "no", true: "yes"}
-		fmt.Printf("Fetched: \t%s\n", yesno[appsStatus.AreFetched()])
+		fmt.Printf("BytesFetched: \t%s\n", yesno[appsStatus.AreFetched()])
 		fmt.Printf("Installed: \t%s\n", yesno[appsStatus.AreInstalled()])
 		fmt.Printf("Running: \t%s\n", yesno[appsStatus.AreRunning()])
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/foundriesio/composeapp
 
-go 1.22
+go 1.24
 
 require (
 	github.com/compose-spec/compose-go v1.20.2

--- a/internal/progress/reporter_test.go
+++ b/internal/progress/reporter_test.go
@@ -48,10 +48,8 @@ func TestReporter_BlockingWithRetry(t *testing.T) {
 	})
 
 	for i := 0; i < maxProgress; i++ {
-		for {
-			if progressReporter.Update(i) {
-				break
-			}
+		for !progressReporter.Update(i) {
+			// loop until Update(i) returns true
 		}
 	}
 }

--- a/pkg/compose/app.go
+++ b/pkg/compose/app.go
@@ -100,16 +100,17 @@ func (t *AppTree) Walk(fn NodeProcessor) error {
 
 func (t *AppTree) Print() {
 	err := t.Walk(func(node *TreeNode, depth int) error {
-		if depth == 0 {
+		switch depth {
+		case 0:
 			id := node.Ref()
 			if len(id) == 0 {
 				id = node.Descriptor.Digest.String()
 			}
 			fmt.Printf("%s: %s, %d\n", node.Type, id, node.Descriptor.Size)
-		} else if depth == 1 {
+		case 1:
 			fmt.Printf("%*s\n", 9, "|")
 			fmt.Printf("%*s %s: %s, %d\n", 11, "|—>", node.Type, node.Descriptor.Digest.String(), node.Descriptor.Size)
-		} else if depth == 2 {
+		case 2:
 			fmt.Printf("%*s\n", 9*depth, "|")
 			(*ImageTree)(node).Print(depth)
 			fmt.Println()

--- a/pkg/compose/blob.go
+++ b/pkg/compose/blob.go
@@ -25,7 +25,6 @@ type (
 		RuntimeSize int64               `json:"runtime_size"`
 		Fetched     int64               `json:"fetched"`
 	}
-	BlobsStatus map[digest.Digest]BlobInfo
 
 	ctxKeyType string
 )

--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -336,9 +336,13 @@ func generateImageLoadManifest(
 			break
 		}
 
-		if !(imageRoot.Type == BlobTypeImageIndex || imageRoot.Type == BlobTypeSkopeoImageIndex) {
+		switch imageRoot.Type {
+		case BlobTypeImageIndex, BlobTypeSkopeoImageIndex:
+			// ok
+		default:
 			return nil, nil, fmt.Errorf("invalid image type is specified: %s", imageRoot.Type)
 		}
+
 		if len(imageRoot.Children) != 1 {
 			return nil, nil, fmt.Errorf("the specified image index has more than one manifest: %s", imageRoot.Ref())
 		}

--- a/pkg/compose/status.go
+++ b/pkg/compose/status.go
@@ -126,15 +126,15 @@ func (e *ErrImageInstall) Error() string {
 }
 
 func (s *AppsStatus) AreRunning() bool {
-	return len(s.RunningStatus.NotRunningApps) == 0
+	return len(s.NotRunningApps) == 0
 }
 
 func (s *AppsStatus) AreInstalled() bool {
-	return len(s.InstallStatus.NotInstalledImages) == 0 && len(s.InstallStatus.NotInstalledCompose) == 0
+	return len(s.NotInstalledImages) == 0 && len(s.NotInstalledCompose) == 0
 }
 
 func (s *AppsStatus) AreFetched() bool {
-	return len(s.FetchStatus.MissingBlobs) == 0
+	return len(s.MissingBlobs) == 0
 }
 
 func CheckAppsStatus(

--- a/pkg/compose/tree.go
+++ b/pkg/compose/tree.go
@@ -61,11 +61,12 @@ func (t *TreeNode) Ref() string {
 }
 
 func (t *TreeNode) GetServiceHash() string {
-	if !(t.Type == BlobTypeImageIndex ||
-		t.Type == BlobTypeSkopeoImageIndex ||
-		t.Type == BlobTypeImageManifest) {
+	switch t.Type {
+	case BlobTypeImageIndex, BlobTypeSkopeoImageIndex, BlobTypeImageManifest:
+	default:
 		return ""
 	}
+
 	if t.Descriptor == nil {
 		return ""
 	}

--- a/pkg/update/fetch.go
+++ b/pkg/update/fetch.go
@@ -123,11 +123,11 @@ func checkAndUpdateBlobStatus(ctx context.Context, b *session, u *runnerImpl, ls
 	for ref, b := range u.Blobs {
 		if s, err := ls.Status(ctx, ref); err == nil {
 			currentUpdateDownloadSize += s.Offset
-			b.Downloaded = s.Offset
+			b.Fetched = s.Offset
 		} else if errors.Is(err, errdefs.ErrNotFound) {
 			if i, err := ls.Info(ctx, b.Descriptor.Digest); err == nil {
 				currentUpdateDownloadSize += i.Size
-				b.Downloaded = i.Size
+				b.Fetched = i.Size
 			}
 		}
 	}

--- a/pkg/update/init.go
+++ b/pkg/update/init.go
@@ -90,7 +90,7 @@ func (u *runnerImpl) initUpdate(ctx context.Context, b *session, options ...Init
 	var downloadSizeTotal int64 = 0
 	var totalSize int64 = 0
 
-	missingBlobs := map[string]*BlobStatus{}
+	missingBlobs := map[string]*compose.BlobInfo{}
 	u.Blobs = missingBlobs
 
 	if opts.ProgressReporter != nil {
@@ -125,15 +125,13 @@ func (u *runnerImpl) initUpdate(ctx context.Context, b *session, options ...Init
 				blobStoreSize := compose.AlignToBlockSize(node.Descriptor.Size, u.config.BlockSize)
 				blobRuntimeSize := app.GetBlobRuntimeSize(node.Descriptor, u.config.Platform.Architecture, u.config.BlockSize)
 
-				missingBlobs[blobURI] = &BlobStatus{
-					BlobInfo: compose.BlobInfo{
-						Descriptor:  node.Descriptor,
-						State:       bs,
-						Type:        node.Type,
-						StoreSize:   blobStoreSize,
-						RuntimeSize: blobRuntimeSize,
-					},
-					Downloaded: 0,
+				missingBlobs[blobURI] = &compose.BlobInfo{
+					Descriptor:  node.Descriptor,
+					State:       bs,
+					Type:        node.Type,
+					StoreSize:   blobStoreSize,
+					RuntimeSize: blobRuntimeSize,
+					Fetched:     0,
 				}
 				storeSizeTotal += blobStoreSize
 				runtimeSizeTotal += blobStoreSize

--- a/pkg/update/init.go
+++ b/pkg/update/init.go
@@ -143,7 +143,7 @@ func (u *runnerImpl) initUpdate(ctx context.Context, b *session, options ...Init
 				opts.ProgressReporter.Update(p)
 			}
 
-			u.TotalBlobDownloadSize = downloadSizeTotal
+			u.TotalBlobsBytes = downloadSizeTotal
 			u.Progress = int(float64(p.Current) / float64(p.Total) * 100)
 			if err := b.write(&u.Update); err != nil {
 				return err

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -23,22 +23,17 @@ type (
 
 	State string
 
-	BlobStatus struct {
-		compose.BlobInfo
-		Downloaded int64 `json:"downloaded"`
-	}
-
 	Update struct {
-		ID                    string                 `json:"id"`
-		ClientRef             string                 `json:"client_ref"`
-		State                 State                  `json:"state"`
-		Progress              int                    `json:"progress"`
-		CreationTime          time.Time              `json:"timestamp"`
-		UpdateTime            time.Time              `json:"update_time"`
-		URIs                  []string               `json:"uris"`
-		Blobs                 map[string]*BlobStatus `json:"blobs"`
-		TotalBlobDownloadSize int64                  `json:"total_blob_download_size"`
-		LoadedImages          map[string]struct{}    `json:"loaded_images"`
+		ID                    string                       `json:"id"`
+		ClientRef             string                       `json:"client_ref"`
+		State                 State                        `json:"state"`
+		Progress              int                          `json:"progress"`
+		CreationTime          time.Time                    `json:"timestamp"`
+		UpdateTime            time.Time                    `json:"update_time"`
+		URIs                  []string                     `json:"uris"`
+		Blobs                 map[string]*compose.BlobInfo `json:"blobs"`
+		TotalBlobDownloadSize int64                        `json:"total_blob_download_size"`
+		LoadedImages          map[string]struct{}          `json:"loaded_images"`
 	}
 
 	runnerImpl struct {

--- a/test/compose/Dockerfile
+++ b/test/compose/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22-alpine
+FROM golang:1.24-alpine
 
 ARG REG_CERT=test/compose/registry/certs/registry.crt
 ARG SRC_DIR=$PWD

--- a/test/integration/edge_cases_test.go
+++ b/test/integration/edge_cases_test.go
@@ -41,7 +41,7 @@ services:
     image: registry:5000/factory/runner-image:v0.1
     command: sh -c "while true; do sleep 60; done"
     environment:
-    - VERSION = 0.1
+    - VERSION=0.1
 `
 	appComposeDef02 := `
 services:
@@ -49,7 +49,7 @@ services:
     image: registry:5000/factory/runner-image:v0.1
     command: sh -c "while true; do sleep 60; done"
     environment:
-    - VERSION = 0.2
+    - VERSION=0.2
 `
 	app := f.NewApp(t, appComposeDef)
 	app.Publish(t)
@@ -155,7 +155,7 @@ services:
     image: registry:5000/factory/runner-image:v0.1
     command: sh -c "while true; do sleep 60; done"
     environment:
-    - VERSION = 0.1
+    - VERSION=0.1
 `
 	appComposeDef02 := `
 services:
@@ -163,7 +163,7 @@ services:
     image: registry:5000/factory/runner-image:v0.1
     command: sh -c "while true; do sleep 60; done"
     environment:
-    - VERSION = 0.2
+    - VERSION=0.2
 `
 	app := f.NewApp(t, appComposeDef)
 	app.Publish(t, f.WithAppBundleIndexes(false))

--- a/test/integration/image_loading_test.go
+++ b/test/integration/image_loading_test.go
@@ -88,7 +88,7 @@ func loadImages(t *testing.T, ctx context.Context, cli *client.Client, app compo
 			if imageRoot.Type == compose.BlobTypeImageManifest {
 				break
 			}
-			if !(imageRoot.Type == compose.BlobTypeImageIndex || imageRoot.Type == compose.BlobTypeSkopeoImageIndex) {
+			if imageRoot.Type != compose.BlobTypeImageIndex && imageRoot.Type != compose.BlobTypeSkopeoImageIndex {
 				t.Fatalf("invalid image type is specified: %s", imageRoot.Type)
 			}
 			if len(imageRoot.Children) != 1 {

--- a/test/integration/update_test.go
+++ b/test/integration/update_test.go
@@ -138,7 +138,7 @@ services:
 	}
 	s, err = compose.CheckAppsStatus(ctx, cfg, []string{app.PublishedUri})
 	f.Check(t, err)
-	if !(s.AreFetched() && s.AreInstalled()) {
+	if !s.AreFetched() || !s.AreInstalled() {
 		t.Fatalf("apps are supposed to be fetched and installed")
 	}
 	if s.AreRunning() {
@@ -153,7 +153,7 @@ services:
 
 	s, err = compose.CheckAppsStatus(ctx, cfg, []string{app.PublishedUri})
 	f.Check(t, err)
-	if !(s.AreFetched() && s.AreInstalled() && s.AreRunning()) {
+	if !s.AreFetched() || !s.AreInstalled() || !s.AreRunning() {
 		t.Fatalf("apps are supposed to be fetched and installed and running")
 	}
 
@@ -313,7 +313,7 @@ services:
 
 	appsStatus, err = compose.CheckAppsStatus(ctx, cfg, nil)
 	f.Check(t, err)
-	if !(len(appsStatus.Apps) == 1 && appsStatus.Apps[0].Ref().String() == app.PublishedUri) {
+	if len(appsStatus.Apps) != 1 || appsStatus.Apps[0].Ref().String() != app.PublishedUri {
 		t.Fatalf("invalid apps status; expected just one app: %s\n", app.PublishedUri)
 	}
 	if !appsStatus.AreFetched() {
@@ -417,7 +417,7 @@ services:
 
 	appsStatus, err = compose.CheckAppsStatus(ctx, cfg, nil)
 	f.Check(t, err)
-	if !(len(appsStatus.Apps) == 1 && appsStatus.Apps[0].Ref().String() == app.PublishedUri) {
+	if len(appsStatus.Apps) != 1 || appsStatus.Apps[0].Ref().String() != app.PublishedUri {
 		t.Fatalf("invalid apps status; expected just one app: %s\n", app.PublishedUri)
 	}
 	if !appsStatus.AreFetched() {


### PR DESCRIPTION
Set of changes aimed to cleanup and improve the code related to tracking blob download progress.

- Remove obsolete type representing blobs status.

- Use the same structure to represent a blob fetch status for both `composectl pull/check` and `composectl update` commands.

- Switch to golang v1.24 and golangci-lint v2.1.6.

- Improve output of update fetching progress.
