### PR TITLE
Timeouts

### DIFF
--- a/cmd/composectl/cmd/check.go
+++ b/cmd/composectl/cmd/check.go
@@ -279,9 +279,7 @@ func getAppStoreAndDstBlobProvider(srcStorePath string, local bool) (srcBlobProv
 		// to Registry. Requires app manifest and app archive presence in the local store, otherwise fails.
 		srcBlobProvider = store
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
-		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
-		srcBlobProvider = compose.NewRemoteBlobProvider(resolver)
+		srcBlobProvider = compose.NewRemoteBlobProviderFromConfig(config)
 	}
 	return
 }

--- a/cmd/composectl/cmd/compose.go
+++ b/cmd/composectl/cmd/compose.go
@@ -43,9 +43,7 @@ func doOutputComposeFile(cmd *cobra.Command, args []string, opts *composeOptions
 	if len(*opts.SrcStorePath) > 0 {
 		blobProvider = compose.NewStoreBlobProvider(compose.GetBlobsRootFor(*opts.SrcStorePath))
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
-		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
-		blobProvider = compose.NewRemoteBlobProvider(resolver)
+		blobProvider = compose.NewRemoteBlobProviderFromConfig(config)
 	}
 	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), blobProvider, platforms.OnlyStrict(config.Platform), args[0])
 	DieNotNil(err)

--- a/cmd/composectl/cmd/inspect.go
+++ b/cmd/composectl/cmd/inspect.go
@@ -22,10 +22,8 @@ func init() {
 func inspectApp(cmd *cobra.Command, args []string) {
 	appRef := args[0]
 
-	authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
-	resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
 	fmt.Printf("Inspecting App %s...", appRef)
-	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), compose.NewRemoteBlobProvider(resolver), platforms.All, appRef)
+	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), compose.NewRemoteBlobProviderFromConfig(config), platforms.All, appRef)
 	DieNotNil(err)
 	fmt.Println("ok")
 	app.Tree().Print()

--- a/cmd/composectl/cmd/manifest.go
+++ b/cmd/composectl/cmd/manifest.go
@@ -42,9 +42,7 @@ func doOutputManifest(cmd *cobra.Command, args []string, opts *manifestOptions) 
 	if len(*opts.SrcStorePath) > 0 {
 		blobProvider = compose.NewStoreBlobProvider(compose.GetBlobsRootFor(*opts.SrcStorePath))
 	} else {
-		authorizer := compose.NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
-		resolver := compose.NewResolver(authorizer, config.ConnectTimeout)
-		blobProvider = compose.NewRemoteBlobProvider(resolver)
+		blobProvider = compose.NewRemoteBlobProviderFromConfig(config)
 	}
 	b, err := compose.ReadBlobWithReadLimit(cmd.Context(), blobProvider, args[0], v1.AppManifestMaxSize)
 	DieNotNil(err)

--- a/cmd/composectl/cmd/root.go
+++ b/cmd/composectl/cmd/root.go
@@ -28,6 +28,7 @@ var (
 	arch              string
 	dockerHost        string
 	connectTimeout    int
+	readTimeout       int
 	defConnectTimeout string
 	showConfigFile    bool
 
@@ -81,6 +82,8 @@ func init() {
 	rootCmd.PersistentFlags().StringVarP(&dockerHost, "host", "H", "", "path to the socket on which the Docker daemon listens")
 	rootCmd.PersistentFlags().IntVarP(&connectTimeout, "connect-timeout", "", int(config.ConnectTimeout.Seconds()),
 		"timeout in seconds for establishing a connection to a container registry and an authentication service")
+	rootCmd.PersistentFlags().IntVarP(&readTimeout, "read-timeout", "", int(config.ReadTimeout.Seconds()),
+		"timeout in seconds for reading data from a socket buffer when communicating with a container registry or an authentication service")
 	rootCmd.PersistentFlags().BoolVarP(&showConfigFile, "show-config", "C", false, "print paths of the applied config files")
 	rootCmd.AddCommand(updatectl.UpdateCmd)
 	rootCmd.AddCommand(versionCmd)
@@ -95,6 +98,7 @@ func initConfig() {
 	config.StoreRoot = storeRoot
 	config.ComposeRoot = composeRoot
 	config.ConnectTimeout = time.Duration(connectTimeout) * time.Second
+	config.ReadTimeout = time.Duration(readTimeout) * time.Second
 	config.DockerCfg = cfg
 	config.DockerHost = dockerHost
 	if len(arch) > 0 {

--- a/pkg/compose/auth.go
+++ b/pkg/compose/auth.go
@@ -4,21 +4,13 @@ import (
 	"fmt"
 	"github.com/containerd/containerd/remotes/docker"
 	"github.com/docker/cli/cli/config/configfile"
-	"net"
 	"net/http"
-	"time"
 )
 
-func NewRegistryAuthorizer(cfg *configfile.ConfigFile, connectTimeout time.Duration) docker.Authorizer {
+func NewRegistryAuthorizer(cfg *configfile.ConfigFile, client *http.Client) docker.Authorizer {
 	return docker.NewDockerAuthorizer(
 		docker.WithAuthCreds(getAuthCreds(cfg)),
-		docker.WithAuthClient(&http.Client{
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: connectTimeout,
-				}).DialContext,
-			},
-		}),
+		docker.WithAuthClient(client),
 	)
 }
 

--- a/pkg/compose/blob.go
+++ b/pkg/compose/blob.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/remotes"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
@@ -141,22 +140,7 @@ func CheckBlob(ctx context.Context, provider BlobProvider, dgst digest.Digest, o
 	return state, checkErr
 }
 
-func CopyBlob(ctx context.Context, resolver remotes.Resolver, ref string, desc ocispec.Descriptor, store content.Store, force bool) error {
-	f, err := resolver.Fetcher(ctx, ref)
-	if err != nil {
-		return err
-	}
-	r, err := f.Fetch(ctx, desc)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-
-	return copyBlob(ctx, r, ref, desc, store, force)
-}
-
-// TODO: it can be method of AppStore interface { content.Store
-func copyBlob(ctx context.Context, r io.ReadCloser, ref string, desc ocispec.Descriptor, store content.Store, force bool) error {
+func CopyBlob(ctx context.Context, r io.ReadCloser, ref string, desc ocispec.Descriptor, store content.Store, force bool) error {
 	var err error
 	var w content.Writer
 	for {

--- a/pkg/compose/blob.go
+++ b/pkg/compose/blob.go
@@ -155,15 +155,6 @@ func CopyBlob(ctx context.Context, resolver remotes.Resolver, ref string, desc o
 	return copyBlob(ctx, r, ref, desc, store, force)
 }
 
-func CopyLocalBlob(ctx context.Context, path string, ref string, desc ocispec.Descriptor, store content.Store, force bool) error {
-	r, err := os.OpenFile(path, os.O_RDONLY, 0600)
-	if err != nil {
-		return err
-	}
-	defer r.Close()
-	return copyBlob(ctx, r, ref, desc, store, force)
-}
-
 // TODO: it can be method of AppStore interface { content.Store
 func copyBlob(ctx context.Context, r io.ReadCloser, ref string, desc ocispec.Descriptor, store content.Store, force bool) error {
 	var err error

--- a/pkg/compose/config.go
+++ b/pkg/compose/config.go
@@ -15,6 +15,7 @@ type (
 		DockerHost      string
 		Platform        specs.Platform
 		ConnectTimeout  time.Duration
+		ReadTimeout     time.Duration
 		AppLoader       AppLoader
 		AppStoreFactory func() (AppStore, error)
 		BlockSize       int64

--- a/pkg/compose/http_client.go
+++ b/pkg/compose/http_client.go
@@ -1,0 +1,17 @@
+package compose
+
+import (
+	"net"
+	"net/http"
+	"time"
+)
+
+func NewHttpClient(connectTimeout time.Duration) *http.Client {
+	return &http.Client{
+		Transport: &http.Transport{
+			DialContext: (&net.Dialer{
+				Timeout: connectTimeout,
+			}).DialContext,
+		},
+	}
+}

--- a/pkg/compose/http_client.go
+++ b/pkg/compose/http_client.go
@@ -1,17 +1,53 @@
 package compose
 
 import (
+	"crypto/tls"
 	"net"
 	"net/http"
 	"time"
 )
 
 func NewHttpClient(connectTimeout time.Duration) *http.Client {
+	// Make a copy of the default transport to avoid modifying the global default
+	t := http.DefaultTransport.(*http.Transport).Clone()
+
+	// Set the transport's DialContext to use a custom dialer with:
+	// 1. the TCP connection timeout
+	// 2. a keep-alive period of 30 seconds
+	t.DialContext = (&net.Dialer{
+		Timeout:   connectTimeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+
+	// Set the transport's TLSHandshakeTimeout and ResponseHeaderTimeout,
+	// so a client will not hang indefinitely if the server does not respond or network goes down.
+	t.TLSHandshakeTimeout = connectTimeout
+	t.ResponseHeaderTimeout = connectTimeout
+
+	// Set the transport's IdleConnTimeout to close idle connections after 30 seconds,
+	// to prevent resource leaks in case of long-lived connections.
+	// 30 seconds is a reasonable default since composectl:
+	// 1. pulls metadata layers one by one without any significant delay
+	// 2. pulls image blobs one by one, without any significant delay
+	t.IdleConnTimeout = 30 * time.Second
+
+	// Set the transport's MaxIdleConns and MaxIdleConnsPerHost to limit the number of idle connections.
+	// If app blobs are pulled one by one, we don't need to keep many idle connections.
+	// Effectively we need just one idle connection per host, so this configuration enables 2 idle connections per host.
+	t.MaxIdleConns = 10
+	t.MaxIdleConnsPerHost = 2
+
+	// Disable HTTP/2 entirely since it's not needed if usually a single http request is made to pull a blob data and
+	// a few sequential requests to authorize a request for a blob or metadata.
+	// Also, HTTP/2 require more resources on a client side, so disabling it will reduce memory usage.
+	t.ForceAttemptHTTP2 = false
+	t.TLSNextProto = make(map[string]func(string, *tls.Conn) http.RoundTripper)
+	// Force HTTP/1.1 for TLS ALPN, required for disabling HTTP/2
+	t.TLSClientConfig = &tls.Config{
+		NextProtos: []string{"http/1.1"},
+	}
+
 	return &http.Client{
-		Transport: &http.Transport{
-			DialContext: (&net.Dialer{
-				Timeout: connectTimeout,
-			}).DialContext,
-		},
+		Transport: t,
 	}
 }

--- a/pkg/compose/provider.go
+++ b/pkg/compose/provider.go
@@ -60,7 +60,7 @@ func NewLocalBlobProvider(fileProvider content.Store) BlobProvider {
 }
 
 func NewRemoteBlobProviderFromConfig(config *Config) BlobProvider {
-	client := NewHttpClient(config.ConnectTimeout)
+	client := NewHttpClient(config.ConnectTimeout, config.ReadTimeout)
 	authorizer := NewRegistryAuthorizer(config.DockerCfg, client)
 	resolver := NewResolver(authorizer, client)
 	return newRemoteBlobProvider(resolver)

--- a/pkg/compose/provider.go
+++ b/pkg/compose/provider.go
@@ -60,8 +60,9 @@ func NewLocalBlobProvider(fileProvider content.Store) BlobProvider {
 }
 
 func NewRemoteBlobProviderFromConfig(config *Config) BlobProvider {
-	authorizer := NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
-	resolver := NewResolver(authorizer, config.ConnectTimeout)
+	client := NewHttpClient(config.ConnectTimeout)
+	authorizer := NewRegistryAuthorizer(config.DockerCfg, client)
+	resolver := NewResolver(authorizer, client)
 	return newRemoteBlobProvider(resolver)
 }
 

--- a/pkg/compose/provider.go
+++ b/pkg/compose/provider.go
@@ -58,6 +58,12 @@ func NewLocalBlobProvider(fileProvider content.Store) BlobProvider {
 	}
 }
 
+func NewRemoteBlobProviderFromConfig(config *Config) BlobProvider {
+	authorizer := NewRegistryAuthorizer(config.DockerCfg, config.ConnectTimeout)
+	resolver := NewResolver(authorizer, config.ConnectTimeout)
+	return NewRemoteBlobProvider(resolver)
+}
+
 func NewRemoteBlobProvider(resolver remotes.Resolver) BlobProvider {
 	return &remoteBlobProvider{
 		resolver: resolver,

--- a/pkg/compose/reader.go
+++ b/pkg/compose/reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"io"
 )
 
@@ -15,6 +16,7 @@ type (
 		ExpectedDigest digest.Digest
 		ExpectedSize   int64
 		ReadLimit      int64
+		Descriptor     ocispec.Descriptor
 	}
 
 	ErrBlobDigestMismatch struct {
@@ -140,6 +142,12 @@ func WithExpectedDigest(digest digest.Digest) func(opts *SecureReadParams) {
 func WithReadLimit(limit int64) func(opts *SecureReadParams) {
 	return func(opts *SecureReadParams) {
 		opts.ReadLimit = limit
+	}
+}
+
+func WithDescriptor(desc ocispec.Descriptor) func(opts *SecureReadParams) {
+	return func(opts *SecureReadParams) {
+		opts.Descriptor = desc
 	}
 }
 

--- a/pkg/compose/resolver.go
+++ b/pkg/compose/resolver.go
@@ -3,25 +3,14 @@ package compose
 import (
 	"github.com/containerd/containerd/remotes"
 	"github.com/containerd/containerd/remotes/docker"
-	"net"
 	"net/http"
-	"time"
 )
 
-func NewResolver(authorizer docker.Authorizer, connectTimeout time.Duration) remotes.Resolver {
-	ropts := []docker.RegistryOpt{
-		docker.WithAuthorizer(authorizer),
-		docker.WithClient(&http.Client{
-			Transport: &http.Transport{
-				DialContext: (&net.Dialer{
-					Timeout: connectTimeout,
-				}).DialContext,
-			},
-		}),
-	}
-	//TODO: consider using options.Hosts = config.ConfigureHosts(ctx, hostOptions)
+func NewResolver(authorizer docker.Authorizer, client *http.Client) remotes.Resolver {
 	return docker.NewResolver(docker.ResolverOptions{
-		Hosts: docker.ConfigureDefaultRegistries(ropts...),
-	},
-	)
+		Hosts: docker.ConfigureDefaultRegistries(
+			docker.WithAuthorizer(authorizer),
+			docker.WithClient(client),
+		),
+	})
 }

--- a/pkg/compose/status.go
+++ b/pkg/compose/status.go
@@ -424,12 +424,6 @@ func (s Services) find(imageNode *TreeNode) (foundService *Service) {
 	return
 }
 
-func newRemoteBlobProvider(c *Config) BlobProvider {
-	authorizer := NewRegistryAuthorizer(c.DockerCfg, c.ConnectTimeout)
-	resolver := NewResolver(authorizer, c.ConnectTimeout)
-	return NewRemoteBlobProvider(resolver)
-}
-
 func checkImageInstallation(installedImages *InstalledImagesInfo, uri string) (bool, error) {
 	if _, ok := installedImages.InstalledImageRefs[uri]; ok {
 		return true, nil
@@ -504,7 +498,7 @@ func loadAppTrees(ctx context.Context,
 	for _, appRef := range appRefs {
 		app, err := cfg.AppLoader.LoadAppTree(ctx, blobProvider, platforms.OnlyStrict(cfg.Platform), appRef)
 		if fallbackLoadingFromRemote && errors.Is(err, ErrAppNotFound) {
-			app, err = cfg.AppLoader.LoadAppTree(ctx, newRemoteBlobProvider(cfg),
+			app, err = cfg.AppLoader.LoadAppTree(ctx, NewRemoteBlobProviderFromConfig(cfg),
 				platforms.OnlyStrict(cfg.Platform), appRef)
 		}
 		if err != nil {

--- a/pkg/compose/v1/config.go
+++ b/pkg/compose/v1/config.go
@@ -26,7 +26,7 @@ const (
 	DefaultRootDir        = ".composeapps"
 	DefaultStoreDir       = "store"
 	DefaultComposeDir     = "projects"
-	DefaultConnectTimeout = time.Duration(30) * time.Second
+	DefaultConnectTimeout = time.Duration(2) * time.Minute
 	DefaultDBFileName     = "updates.db"
 )
 

--- a/pkg/compose/v1/config.go
+++ b/pkg/compose/v1/config.go
@@ -16,6 +16,7 @@ type (
 		StoreRoot      string
 		ComposeRoot    string
 		ConnectTimeout time.Duration
+		ReadTimeout    time.Duration
 		SkopeoSupport  bool
 		UpdateDBPath   string
 	}
@@ -27,6 +28,7 @@ const (
 	DefaultStoreDir       = "store"
 	DefaultComposeDir     = "projects"
 	DefaultConnectTimeout = time.Duration(2) * time.Minute
+	DefaultReadTimeout    = time.Duration(15) * time.Minute
 	DefaultDBFileName     = "updates.db"
 )
 
@@ -63,6 +65,7 @@ func WithConnectTimeout(timeout time.Duration) ConfigOpt {
 func NewDefaultConfig(options ...ConfigOpt) (*compose.Config, error) {
 	opts := &ConfigOpts{
 		ConnectTimeout: DefaultConnectTimeout,
+		ReadTimeout:    DefaultReadTimeout,
 	}
 	for _, opt := range options {
 		opt(opts)
@@ -121,6 +124,7 @@ func NewDefaultConfig(options ...ConfigOpt) (*compose.Config, error) {
 		DockerCfg:      dockerCfg,
 		Platform:       platform,
 		ConnectTimeout: opts.ConnectTimeout,
+		ReadTimeout:    opts.ReadTimeout,
 		AppLoader:      NewAppLoader(),
 		AppStoreFactory: func() (compose.AppStore, error) {
 			return NewAppStore(opts.StoreRoot, platform, opts.SkopeoSupport)

--- a/pkg/update/init.go
+++ b/pkg/update/init.go
@@ -50,9 +50,7 @@ func (u *runnerImpl) initUpdate(ctx context.Context, b *session, options ...Init
 		}
 	}()
 
-	authorizer := compose.NewRegistryAuthorizer(u.config.DockerCfg, u.config.ConnectTimeout)
-	resolver := compose.NewResolver(authorizer, u.config.ConnectTimeout)
-	srcBlobProvider := compose.NewRemoteBlobProvider(resolver)
+	srcBlobProvider := compose.NewRemoteBlobProviderFromConfig(u.config)
 
 	p := InitProgress{
 		State:   UpdateInitStateLoadingTree,


### PR DESCRIPTION
- Code refactoring to maximize reusing the source code related to http client instantiation.
- Setting timeouts for all stages of https connection establishing.
- Adding support of a read timeout so a client does not hang forever in a connection drops while downloading blob data.