### PR TITLE
fetch: Support fetching blobs from local dir

### DIFF
--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -62,7 +62,8 @@ func pullApps(cmd *cobra.Command, args []string) {
 
 		err := compose.FetchBlobs(cmd.Context(), config, cr.MissingBlobs,
 			compose.WithProgressPollInterval(1000),
-			compose.WithFetchProgress(getFetchProgressHandler()))
+			compose.WithFetchProgress(getFetchProgressHandler()),
+			compose.WithSourcePath(*pullSrcStorePath))
 		DieNotNil(err, "failed to fetch blobs")
 		fmt.Println("\n\nApp blobs pull completed at " + time.Now().UTC().Format("15:04:05 02 Jan 2006"))
 	}

--- a/pkg/compose/provider.go
+++ b/pkg/compose/provider.go
@@ -101,7 +101,12 @@ func (store *storeBlobProvider) GetReadCloser(ctx context.Context, opts ...Secur
 	if err != nil {
 		return nil, err
 	}
-	return NewSecureReadCloser(f, newOpts...)
+	if p.DisableSecureRead {
+		// If secure read is disabled, we return the file object directly
+		return f, nil
+	} else {
+		return NewSecureReadCloser(f, newOpts...)
+	}
 }
 
 func (store *storeBlobProvider) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
@@ -147,10 +152,10 @@ func (r *remoteBlobProvider) GetReadCloser(ctx context.Context, opts ...SecureRe
 	if len(p.Ref) == 0 {
 		return nil, fmt.Errorf("missing mandatory parameter `SecureReadParams.Ref`")
 	}
-	if len(p.ExpectedDigest) > 0 || p.ExpectedSize > 0 || p.ReadLimit > 0 {
-		return r.getSecureReadCloser(ctx, &p, opts...)
-	} else {
+	if p.DisableSecureRead {
 		return r.getReadCloser(ctx, &p)
+	} else {
+		return r.getSecureReadCloser(ctx, &p, opts...)
 	}
 }
 

--- a/pkg/compose/reader.go
+++ b/pkg/compose/reader.go
@@ -12,11 +12,12 @@ type (
 	SecureReadOptions func(opts *SecureReadParams)
 
 	SecureReadParams struct {
-		Ref            string
-		ExpectedDigest digest.Digest
-		ExpectedSize   int64
-		ReadLimit      int64
-		Descriptor     ocispec.Descriptor
+		Ref               string
+		ExpectedDigest    digest.Digest
+		ExpectedSize      int64
+		ReadLimit         int64
+		Descriptor        ocispec.Descriptor
+		DisableSecureRead bool
 	}
 
 	ErrBlobDigestMismatch struct {
@@ -148,6 +149,12 @@ func WithReadLimit(limit int64) func(opts *SecureReadParams) {
 func WithDescriptor(desc ocispec.Descriptor) func(opts *SecureReadParams) {
 	return func(opts *SecureReadParams) {
 		opts.Descriptor = desc
+	}
+}
+
+func WithSecureReadOff() func(opts *SecureReadParams) {
+	return func(opts *SecureReadParams) {
+		opts.DisableSecureRead = true
 	}
 }
 


### PR DESCRIPTION
- Extend the `FetchBlobs` function with support of fetching blobs from a local directory. Introduced the new fetch option allowing users specify the source directory to fetch blobs from.

- Adjust implementation of the store provider and the secure reader so it allows reading blobs from a local directory without applying security/integrity checks (size, hash, etc). We need it in this particular case because the writer does all those checks, hence we don't need to do it in the blob data reader.