### PR TITLE
Fix concurrency issue

### DIFF
--- a/pkg/compose/fetch.go
+++ b/pkg/compose/fetch.go
@@ -250,7 +250,7 @@ func NewReadMonitor(ctx context.Context, r io.ReadSeekCloser, b *BlobFetchProgre
 		ReadSeekCloser: r,
 		ctx:            ctx,
 		b:              b,
-		stopChan:       make(chan struct{}),
+		stopChan:       make(chan struct{}, 1),
 		statChan:       make(chan readStat, 100),
 	}
 }


### PR DESCRIPTION
Make sure the app pull does not hang in case very fast copying when the read monitor starts listening for events after the pull completes.