### PR TITLE
update: Don't fail update if network timeout occurs

### DIFF
--- a/pkg/compose/fetch.go
+++ b/pkg/compose/fetch.go
@@ -171,7 +171,7 @@ func FetchBlobs(ctx context.Context, cfg *Config, blobs BlobsInfo, options ...Fe
 			//r, err := blobProvider.GetReadCloser(ctx, WithRef(bi.Ref()), WithDescriptor(*bi.Descriptor))
 			r, err := blobProvider.GetReadCloser(ctx, WithRef(bi.Ref()), WithDescriptor(*bi.Descriptor), WithSecureReadOff())
 			if err != nil {
-				return fmt.Errorf("failed to initiate request to fetch blob %s: %v", bi.Descriptor.Digest, err)
+				return fmt.Errorf("failed to initiate request to fetch blob %s: %w", bi.Descriptor.Digest, err)
 			}
 			defer r.Close()
 			blobReader, ok := r.(io.ReadSeekCloser)
@@ -183,7 +183,7 @@ func FetchBlobs(ctx context.Context, cfg *Config, blobs BlobsInfo, options ...Fe
 			rm.Start()
 			defer rm.Stop()
 			if err := CopyBlob(ctx, rm, bi.Ref(), *bi.Descriptor, ls, true); err != nil {
-				return fmt.Errorf("failed to fetch blob %s: %v", bi.Descriptor.Digest, err)
+				return fmt.Errorf("failed to fetch blob %s: %w", bi.Descriptor.Digest, err)
 			}
 			return nil
 		}()

--- a/pkg/compose/v1/app.go
+++ b/pkg/compose/v1/app.go
@@ -119,7 +119,7 @@ func (l *appLoader) LoadAppTree(ctx context.Context, provider compose.BlobProvid
 		if errors.Is(err, compose.ErrAppNotFound) {
 			return nil, err
 		}
-		return nil, fmt.Errorf("failed to read app manifest: %s", err)
+		return nil, fmt.Errorf("failed to read app manifest: %w", err)
 	}
 	appTree := compose.AppTree{Descriptor: rootDesc, Type: compose.BlobTypeAppManifest}
 


### PR DESCRIPTION
- Wrap internal errors correctly so upper layer code can unwrap them and detect the underlying error type.

- Don't move an update state to the `failed` state if a connection or read timeout occurs during update initialization of fetching. It allows to resume the update process from a point where it was interrupted by timeout instead of requiring a caller/user to create a new update.