### PR TITLE
update: Don't do fetch if nothing to fetch

### DIFF
--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -260,7 +260,7 @@ func (u *runnerImpl) Fetch(ctx context.Context, options ...compose.FetchOption) 
 			}
 		}()
 
-		if len(u.URIs) > 0 {
+		if len(u.Blobs) > 0 {
 			err = u.fetch(ctx, db, options...)
 		}
 		return err


### PR DESCRIPTION
If moving an update state to "fetched" or "installed" at the update initialization is turned off then it can happen that there is 0 bytes to fetch when a user invokes the fetch command. In such cases it does not make sense to start the app blobs fetching procedure at all.