### PR TITLE
Unify and improve app start

### DIFF
--- a/cmd/composectl/cmd/run.go
+++ b/cmd/composectl/cmd/run.go
@@ -2,12 +2,9 @@ package composectl
 
 import (
 	"fmt"
-	"github.com/containerd/containerd/platforms"
 	"github.com/foundriesio/composeapp/pkg/compose"
-	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
+	"github.com/foundriesio/composeapp/pkg/update"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
 	"strings"
 )
 
@@ -48,44 +45,45 @@ func init() {
 }
 
 func runApps(cmd *cobra.Command, opts *runOptions) {
-	cs, err := v1.NewAppStore(config.StoreRoot, config.Platform)
-	DieNotNil(err)
-	apps, err := cs.ListApps(cmd.Context())
+	apps, err := compose.ListApps(cmd.Context(), config)
 	DieNotNil(err)
 
-	foundApps := map[string]bool{}
+	checkedApps := map[string]compose.App{}
 	for _, app := range apps {
-		foundApps[app.Name] = true
+		appName := app.Name()
+		if len(opts.Apps) > 0 && !opts.Apps[appName] {
+			continue
+		}
+		if _, ok := checkedApps[appName]; ok {
+			DieNotNil(fmt.Errorf("cannot start %s since there are two or more versions of it found in the store", appName))
+		}
+		checkedApps[appName] = app
 	}
 	for app := range opts.Apps {
-		if !foundApps[app] {
+		if _, ok := checkedApps[app]; !ok {
 			DieNotNil(fmt.Errorf("specified app is not present in the local store: %s", app))
 		}
 	}
 
-	checkedApps := map[string]compose.App{}
-	for _, app := range apps {
-		if len(opts.Apps) > 0 && !opts.Apps[app.Name] {
-			fmt.Printf("%s: skipping, not in the shortlist\n", app.Name)
-			continue
-		}
-		a, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), cs, platforms.OnlyStrict(config.Platform), app.String())
+	var appURIs []string
+	// Make sure all apps are installed before starting any of them
+	for _, app := range checkedApps {
+		err = compose.Install(cmd.Context(), config, app.Ref().String(),
+			compose.WithInstallProgress(update.GetInstallProgressPrinter()))
 		DieNotNil(err)
-		if _, ok := checkedApps[app.Name]; ok {
-			DieNotNil(fmt.Errorf("cannot start %s since there are two or more versions of it found in the store", app.Name))
-		}
-		checkedApps[app.Name] = a
+		appURIs = append(appURIs, app.Ref().String())
 	}
 
-	for _, app := range checkedApps {
-		fmt.Printf("Installing %s --> %s\n", app.Name(), app.Ref().String())
-		err = v1.InstallApp(cmd.Context(), app, cs, config.GetBlobsRoot(), config.ComposeRoot, config.DockerHost)
-		DieNotNil(err)
-		fmt.Printf("Starting %s --> %s\n", app.Name(), app.Ref().String())
-		cmd := exec.Command("docker", "compose", "up", "-d", "--remove-orphans")
-		cmd.Dir = config.GetAppComposeDir(app.Name())
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		DieNotNil(cmd.Run())
-	}
+	err = compose.StartApps(cmd.Context(), config, appURIs, compose.WithVerboseStart(true),
+		compose.WithStartProgressHandler(func(app compose.App, status compose.AppStartStatus, any interface{}) {
+			switch status {
+			case compose.AppStartStatusStarting:
+				fmt.Printf("Starting %s --> %s\n", app.Name(), app.Ref().String())
+			case compose.AppStartStatusStarted:
+				fmt.Printf("%s has been successfully started\n", app.Name())
+			case compose.AppStartStatusFailed:
+				fmt.Printf("failed to start %s\n", app.Name())
+			}
+		}))
+	DieNotNil(err)
 }

--- a/pkg/compose/start.go
+++ b/pkg/compose/start.go
@@ -1,13 +1,52 @@
 package compose
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/containerd/containerd/platforms"
+	"os"
 	"os/exec"
 )
 
-func StartApps(ctx context.Context, cfg *Config, appURIs []string) error {
+type (
+	StartOptions struct {
+		Verbose         bool
+		ProgressHandler AppStartProgress
+	}
+
+	StartOption func(*StartOptions)
+
+	AppStartStatus   string
+	AppStartProgress func(app App, status AppStartStatus, any interface{})
+)
+
+const (
+	AppStartStatusStarting AppStartStatus = "starting"
+	AppStartStatusStarted  AppStartStatus = "started"
+	AppStartStatusFailed   AppStartStatus = "failed"
+)
+
+func WithVerboseStart(verbose bool) StartOption {
+	return func(o *StartOptions) {
+		o.Verbose = verbose
+	}
+}
+
+func WithStartProgressHandler(handler AppStartProgress) StartOption {
+	return func(o *StartOptions) {
+		o.ProgressHandler = handler
+	}
+}
+
+func StartApps(ctx context.Context, cfg *Config, appURIs []string, options ...StartOption) error {
+	opts := &StartOptions{
+		Verbose: false,
+	}
+	for _, o := range options {
+		o(opts)
+	}
+
 	cs, err := cfg.AppStoreFactory()
 	if err != nil {
 		return err
@@ -23,14 +62,34 @@ func StartApps(ctx context.Context, cfg *Config, appURIs []string) error {
 	}
 
 	for _, app := range apps {
-		// TODO: use the docker compose API to start apps
+		if opts.ProgressHandler != nil {
+			opts.ProgressHandler(app, AppStartStatusStarting, nil)
+		}
 		cmd := exec.Command("docker", "compose", "up", "-d", "--remove-orphans")
 		cmd.Dir = cfg.GetAppComposeDir(app.Name())
-		if _, err := cmd.CombinedOutput(); err != nil {
-			if exitErr, ok := err.(*exec.ExitError); ok {
-				return fmt.Errorf("failed to start %s: %s; %s", app, exitErr.Error(), string(exitErr.Stderr))
+		if opts.Verbose {
+			// Directly connect to stdout/stderr, so we can see the output in real time
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		} else {
+			// Capture stdout/stderr for error reporting
+			var stdout, stderr bytes.Buffer
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+		}
+		if err := cmd.Run(); err != nil {
+			if opts.ProgressHandler != nil {
+				opts.ProgressHandler(app, AppStartStatusFailed, err)
 			}
-			return err
+			if opts.Verbose {
+				return fmt.Errorf("failed to start %s: %w", app, err)
+			} else {
+				return fmt.Errorf("failed to start %s: %w\n\tstdout: %s\n\tstderr: %s", app, err, cmd.Stdout, cmd.Stderr)
+			}
+
+		}
+		if opts.ProgressHandler != nil {
+			opts.ProgressHandler(app, AppStartStatusStarted, nil)
 		}
 	}
 	return nil

--- a/pkg/compose/stop.go
+++ b/pkg/compose/stop.go
@@ -11,11 +11,11 @@ func StopApps(ctx context.Context, cfg *Config, appRefs []string) error {
 	if err != nil {
 		return err
 	}
-	if !status.AreInstalled() {
-		return fmt.Errorf("cannot stop not installed app(s)")
-	}
-	// TODO: use the docker compose API to start apps
 	for _, app := range status.Apps {
+		if _, ok := status.NotInstalledCompose[app.Ref().Digest]; ok {
+			// skip stopping apps with non-installed compose project
+			continue
+		}
 		cmd := exec.Command("docker", "compose", "down")
 		cmd.Dir = cfg.GetAppComposeDir(app.Name())
 		if _, err := cmd.CombinedOutput(); err != nil {

--- a/pkg/update/start.go
+++ b/pkg/update/start.go
@@ -3,43 +3,27 @@ package update
 import (
 	"context"
 	"fmt"
-	"github.com/containerd/containerd/platforms"
 	"github.com/foundriesio/composeapp/pkg/compose"
-	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
-	"os"
-	"os/exec"
-	"path"
 )
 
 func (u *runnerImpl) run(ctx context.Context, b *session) error {
-	cs, err := v1.NewAppStore(u.config.StoreRoot, u.config.Platform)
-	if err != nil {
+	progressStep := 100 / len(u.URIs)
+	if err := compose.StartApps(ctx, u.config, u.URIs,
+		compose.WithVerboseStart(false),
+		compose.WithStartProgressHandler(func(app compose.App, status compose.AppStartStatus, any interface{}) {
+			switch status {
+			case compose.AppStartStatusStarting:
+				fmt.Printf("\tstarting %s --> %s ... ", app.Name(), app.Ref().String())
+			case compose.AppStartStatusStarted:
+				fmt.Println("done")
+				u.Progress += progressStep
+			case compose.AppStartStatusFailed:
+				fmt.Println("failed")
+				u.Progress += progressStep
+			}
+		}),
+	); err != nil {
 		return err
 	}
-
-	apps := map[string]compose.App{}
-	for _, appURI := range u.URIs {
-		app, err := u.config.AppLoader.LoadAppTree(ctx, cs, platforms.OnlyStrict(u.config.Platform), appURI)
-		if err != nil {
-			return err
-		}
-		apps[appURI] = app
-	}
-
-	for _, app := range apps {
-		fmt.Printf("Starting %store --> %store\n", app.Name(), app.Ref().String())
-		cmd := exec.Command("docker", "compose", "up", "-d", "--remove-orphans")
-		cmd.Dir = path.Join(u.config.ComposeRoot, app.Name())
-		cmd.Stderr = os.Stderr
-		cmd.Stdout = os.Stdout
-		err = cmd.Run()
-		if err != nil {
-			return err
-		}
-	}
-
-	u.Progress = 100
-	u.State = StateCompleted
-
 	return nil
 }

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -192,6 +192,7 @@ func (u *runnerImpl) Init(ctx context.Context, appURIs []string, options ...Init
 		defer func() {
 			if err == nil {
 				u.Progress = 100
+				u.State = StateInitialized
 				if opts.CheckStatus && len(u.Blobs) == 0 && u.TotalBlobsBytes == 0 {
 					if s, err := compose.CheckAppsStatus(ctx, u.config, u.URIs); err == nil {
 						if s.AreFetched() {
@@ -204,8 +205,6 @@ func (u *runnerImpl) Init(ctx context.Context, appURIs []string, options ...Init
 							u.State = StateStarted
 						}
 					}
-				} else {
-					u.State = StateInitialized
 				}
 			} else if !errors.Is(err, context.Canceled) && !errors.Is(err, context.DeadlineExceeded) && !isConnectionTimeout(err) {
 				u.State = StateFailed

--- a/pkg/update/update.go
+++ b/pkg/update/update.go
@@ -327,7 +327,8 @@ func (u *runnerImpl) Start(ctx context.Context) error {
 			}
 		}()
 
-		return u.run(ctx, db)
+		err = u.run(ctx, db)
+		return err
 	})
 }
 

--- a/test/fixtures/composectl_cmds.go
+++ b/test/fixtures/composectl_cmds.go
@@ -1,8 +1,6 @@
 package fixtures
 
 import (
-	"crypto/rand"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"github.com/containerd/containerd/images"
@@ -160,8 +158,7 @@ func (a *App) Publish(t *testing.T, publishOpts ...func(*PublishOpts)) {
 
 	t.Run("publish app", func(t *testing.T) {
 		digestFile := path.Join(a.Dir, "digest.sha256")
-		tag, err := randomStringCrypto(7)
-		Check(t, err)
+		tag := randomString(7)
 		args := []string{
 			"publish", "-d", digestFile, baseUri + ":" + tag, "amd64",
 		}
@@ -440,18 +437,8 @@ func runCmd(t *testing.T, appDir string, args ...string) []byte {
 	return output
 }
 
-func randomStringCrypto(length int) (string, error) {
-	bytes := make([]byte, length)
-	_, err := rand.Read(bytes)
-	if err != nil {
-		return "", err
-	}
-
-	return base64.URLEncoding.EncodeToString(bytes)[:length], nil
-}
-
 func randomString(length int) string {
-	const charset = "abcdefghijklmnopqrstuvwxyz"
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 	seededRand := rand2.New(rand2.NewSource(time.Now().UnixNano()))
 	b := make([]byte, length)
 	for i := range b {


### PR DESCRIPTION
Enhance the API function to start apps and use it in both `composectl run` and `composectl update start` commands (avoid code duplication and encapsulate apps start functionality).

It allows to improve `fioup update|start` command output by making it less verbose and more concise.

Some minor fixes.

Allow stopping apps even if some of them are not installed.