### PR TITLE
status_printer: Fix average speed calculation

### DIFF
--- a/pkg/update/status_printer.go
+++ b/pkg/update/status_printer.go
@@ -102,7 +102,9 @@ func GetFetchProgressPrinter() func(status *compose.FetchProgress) {
 		var avgSpeed int64
 		if !start.IsZero() {
 			elapsed = time.Since(start).Round(time.Second)
-			avgSpeed = (status.CurrentBytes - startBytes) / int64(elapsed.Seconds())
+			if elapsed > 0 {
+				avgSpeed = (status.CurrentBytes - startBytes) / int64(elapsed.Seconds())
+			}
 		}
 		var eta time.Duration
 


### PR DESCRIPTION
The rounded `elapsed` time can be zero, so we need to make sure it is not before dividing by it.