### PR TITLE
Client handles start progress

### DIFF
--- a/cmd/composectl/cmd/update/start.go
+++ b/cmd/composectl/cmd/update/start.go
@@ -1,6 +1,8 @@
 package updatectl
 
 import (
+	"fmt"
+	"github.com/foundriesio/composeapp/pkg/compose"
 	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
 	"github.com/foundriesio/composeapp/pkg/update"
 	"github.com/spf13/cobra"
@@ -34,6 +36,15 @@ func runUpdateCmd(cmd *cobra.Command, args []string, opts *runOptions) {
 	updateCtl, err := update.GetCurrentUpdate(cfg)
 	ExitIfNotNil(err)
 
-	err = updateCtl.Start(cmd.Context())
-	ExitIfNotNil(err)
+	ExitIfNotNil(updateCtl.Start(cmd.Context(), compose.WithVerboseStart(false),
+		compose.WithStartProgressHandler(func(app compose.App, status compose.AppStartStatus, any interface{}) {
+			switch status {
+			case compose.AppStartStatusStarting:
+				fmt.Printf("\tstarting %s --> %s ... ", app.Name(), app.Ref().String())
+			case compose.AppStartStatusStarted:
+				fmt.Println("done")
+			case compose.AppStartStatusFailed:
+				fmt.Println("failed")
+			}
+		})))
 }


### PR DESCRIPTION
- Allow a client to handle progress of the updated apps' start.
- Print the start progress in the cmd implementation.