### PR TITLE
update: Fix failed update count

### DIFF
--- a/pkg/update/store.go
+++ b/pkg/update/store.go
@@ -106,7 +106,10 @@ func (s *store) countFailedUpdates(keySuffix string) (int, error) {
 	err = db.View(func(tx *bbolt.Tx) error {
 		b := tx.Bucket([]byte(UpdatesBucketName))
 		cursor := b.Cursor()
-		for k, v := cursor.Last(); k != nil && bytes.HasSuffix(k, []byte(keySuffix)); k, v = cursor.Prev() {
+		for k, v := cursor.Last(); k != nil; k, v = cursor.Prev() {
+			if !bytes.HasSuffix(k, []byte(keySuffix)) {
+				continue
+			}
 			var u Update
 			err := json.Unmarshal(v, &u)
 			if err != nil {


### PR DESCRIPTION
The failed update counter should NOT exit once it finds an update with non-matching suffix. Instead it should iterate over all updates or until it finds a successful update  with the given suffix/client-ref.