### PR TITLE
WIP: provider: Introduce support for satellite server

### DIFF
--- a/pkg/compose/config.go
+++ b/pkg/compose/config.go
@@ -1,10 +1,13 @@
 package compose
 
 import (
-	"github.com/docker/cli/cli/config/configfile"
-	specs "github.com/opencontainers/image-spec/specs-go/v1"
+	"crypto/x509"
+	"net/url"
 	"path/filepath"
 	"time"
+
+	"github.com/docker/cli/cli/config/configfile"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type (
@@ -20,6 +23,9 @@ type (
 		AppStoreFactoryFunc func(c *Config) (AppStore, error)
 		BlockSize           int64
 		DBFilePath          string
+
+		ProxyURL   *url.URL
+		ProxyCerts *x509.CertPool
 	}
 )
 


### PR DESCRIPTION
The satellite server, https://github.com/foundriesio/dg-satellite, needs a way for devices to pick up registry content from it instead of hub.foundries.io. This change introduces a mechanism to tell our provider code to proxy its requests through the satellite server.

The error handling in this is a little awkward but allowed us to bubble up errors w/o having to adjust a lot of users of the API.