### PR TITLE
image_loader: Correctly count image loading responses from dockerd

### DIFF
--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -236,13 +236,11 @@ func LoadImages(ctx context.Context,
 						curImageIndex++
 						curLayerID = ""
 						p.State = ImageLoadStateImageWaiting
-						if curImageIndex < len(imageURIs) {
-							p.ImageID = imageURIs[curImageIndex].URI
-						}
+						p.ImageID = getImageID(imageURIs, curImageIndex)
 					}
 				} else {
 					curLayerID = jm.ID
-					p.ImageID = imageURIs[curImageIndex].URI
+					p.ImageID = getImageID(imageURIs, curImageIndex)
 					if _, ok := layersMap[curLayerID]; ok {
 						p.ID = layersMap[curLayerID][:7]
 					} else {
@@ -275,9 +273,7 @@ func LoadImages(ctx context.Context,
 
 						curImageIndex++
 						curLayerID = ""
-						if curImageIndex < len(imageURIs) {
-							p.ImageID = imageURIs[curImageIndex].URI
-						}
+						p.ImageID = getImageID(imageURIs, curImageIndex)
 						p.State = ImageLoadStateImageWaiting
 					}
 
@@ -424,4 +420,13 @@ func generateImageLoadManifest(
 	}
 
 	return loadManifest, &imageConfig, nil
+}
+
+func getImageID(imageURIs []imageURI2RefCounter, imageIndex int) string {
+	if imageIndex < len(imageURIs) {
+		return imageURIs[imageIndex].URI
+	} else {
+		fmt.Printf("Warning: image index %d is out of range (max %d)\n", imageIndex, len(imageURIs))
+		return "unknown"
+	}
 }


### PR DESCRIPTION
Dockerd emits an "image loaded" response for each tag reference listed in an image manifest. This means that if an image has N tag references, dockerd will send the "image loaded" response N times, even though the image blobs are only loaded once.

Additionally, when a digest reference is used in the "RepoTags" field of an image load manifest, dockerd sends the "image loaded" response only once, regardless of the number of tag references.

This commit updates the image loading logic to account for these behaviors and correctly count the responses.