### PR TITLE
image_loader: Skip warning if expected index to exceed the max

### DIFF
--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -236,11 +236,11 @@ func LoadImages(ctx context.Context,
 						curImageIndex++
 						curLayerID = ""
 						p.State = ImageLoadStateImageWaiting
-						p.ImageID = getImageID(imageURIs, curImageIndex)
+						p.ImageID = getImageID(imageURIs, curImageIndex, false)
 					}
 				} else {
 					curLayerID = jm.ID
-					p.ImageID = getImageID(imageURIs, curImageIndex)
+					p.ImageID = getImageID(imageURIs, curImageIndex, true)
 					if _, ok := layersMap[curLayerID]; ok {
 						p.ID = layersMap[curLayerID][:7]
 					} else {
@@ -273,7 +273,7 @@ func LoadImages(ctx context.Context,
 
 						curImageIndex++
 						curLayerID = ""
-						p.ImageID = getImageID(imageURIs, curImageIndex)
+						p.ImageID = getImageID(imageURIs, curImageIndex, false)
 						p.State = ImageLoadStateImageWaiting
 					}
 
@@ -422,11 +422,11 @@ func generateImageLoadManifest(
 	return loadManifest, &imageConfig, nil
 }
 
-func getImageID(imageURIs []imageURI2RefCounter, imageIndex int) string {
+func getImageID(imageURIs []imageURI2RefCounter, imageIndex int, printWarning bool) string {
 	if imageIndex < len(imageURIs) {
 		return imageURIs[imageIndex].URI
-	} else {
+	} else if printWarning {
 		fmt.Printf("Warning: image index %d is out of range (max %d)\n", imageIndex, len(imageURIs))
-		return "unknown"
 	}
+	return "unknown"
 }


### PR DESCRIPTION
In some cases it is expected that the image index becomes higher than the maximum allowed index. In particular, when the last image is loaded or when the last image is already present in the docker store. The only case when this is a real error is if a client starts receiving messages about loading a new image while the image index is already equal to an overall image count.