### PR TITLE
config: Define proxy providing function in config

### DIFF
--- a/pkg/compose/config.go
+++ b/pkg/compose/config.go
@@ -23,10 +23,13 @@ type (
 		AppStoreFactoryFunc func(c *Config) (AppStore, error)
 		BlockSize           int64
 		DBFilePath          string
-
+		Proxy               ProxyProvider
+	}
+	ProxyConfig struct {
 		ProxyURL   *url.URL
 		ProxyCerts *x509.CertPool
 	}
+	ProxyProvider func() *ProxyConfig
 )
 
 func (c *Config) GetAppComposeDir(appName string) string {

--- a/pkg/compose/provider.go
+++ b/pkg/compose/provider.go
@@ -88,14 +88,15 @@ func (t tokenProxyTripper) RoundTrip(req *http.Request) (*http.Response, error) 
 
 func NewRemoteBlobProviderFromConfig(config *Config) BlobProvider {
 	client := NewHttpClient(config.ConnectTimeout, config.ReadTimeout)
-	if config.ProxyURL != nil {
+	if config.Proxy != nil {
+		proxyConfig := config.Proxy()
 		tpt := tokenProxyTripper{
 			base: client.Transport,
-			host: config.ProxyURL,
+			host: proxyConfig.ProxyURL,
 		}
 
-		if config.ProxyCerts != nil {
-			client.Transport.(*http.Transport).TLSClientConfig.RootCAs = config.ProxyCerts
+		if proxyConfig.ProxyCerts != nil {
+			client.Transport.(*http.Transport).TLSClientConfig.RootCAs = proxyConfig.ProxyCerts
 		}
 		client.Transport = tpt
 	}


### PR DESCRIPTION
Defining a compose app proxy as a function in the configuration provides the compose app API clients to define runtime logic for obtaining URL and/or CA cert of the proxy server.

In particular, a client does not need to know which of the API functions makes a call to a container registry, hence it does not need to set the proxy before invoking each such the API call. Instead composeapp invokes a client provided function/callback to provide the proxy URL and CA whenever a random API function of composeapp needs it.