### PR TITLE
refact(pull): verify local blob integrity before pulling

### DIFF
--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -3,14 +3,15 @@ package composectl
 import (
 	"encoding/json"
 	"fmt"
+	"os"
+	"sync/atomic"
+	"time"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/foundriesio/composeapp/pkg/compose"
 	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
 	"github.com/moby/term"
 	"github.com/spf13/cobra"
-	"os"
-	"sync/atomic"
-	"time"
 )
 
 var (
@@ -45,7 +46,7 @@ func pullApps(cmd *cobra.Command, args []string) {
 	DieNotNil(err)
 
 	cr, ui, apps, err := checkApps(cmd.Context(), args, srcBlobProvider, *pullUsageWatermark,
-		*pullSrcStorePath, false, true)
+		*pullSrcStorePath, false, false)
 	DieNotNil(err, "failed to check apps status")
 	if len(cr.MissingBlobs) > 0 {
 		ui.Print()


### PR DESCRIPTION
Verify hashes of app blobs already present in the local store before running an update/pull operation. This ensures we detect and re-download blobs that have become corrupted due to external factors (e.g., disk degradation).

Checking only the blob size is not sufficient, as corrupted blobs may still match the expected size while having invalid content.