### PR TITLE
refact(pull): verify local blob integrity before pulling

### DIFF
--- a/cmd/composectl/cmd/pull.go
+++ b/cmd/composectl/cmd/pull.go
@@ -45,7 +45,7 @@ func pullApps(cmd *cobra.Command, args []string) {
 	DieNotNil(err)
 
 	cr, ui, apps, err := checkApps(cmd.Context(), args, srcBlobProvider, *pullUsageWatermark,
-		*pullSrcStorePath, false, true)
+		*pullSrcStorePath, false, false)
 	DieNotNil(err, "failed to check apps status")
 	if len(cr.MissingBlobs) > 0 {
 		ui.Print()


### PR DESCRIPTION
Verify hashes of app blobs already present in the local store before running an update/pull operation. This ensures we detect and re-download blobs that have become corrupted due to external factors (e.g., disk degradation).

Checking only the blob size is not sufficient, as corrupted blobs may still match the expected size while having invalid content.