### PR TITLE
cmd: Add optional json format to inspect command output

### DIFF
--- a/cmd/composectl/cmd/inspect.go
+++ b/cmd/composectl/cmd/inspect.go
@@ -1,12 +1,19 @@
 package composectl
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+
 	"github.com/containerd/containerd/platforms"
 	"github.com/foundriesio/composeapp/pkg/compose"
-	"github.com/foundriesio/composeapp/pkg/compose/v1"
+	v1 "github.com/foundriesio/composeapp/pkg/compose/v1"
 	"github.com/spf13/cobra"
 )
+
+type inspectOptions struct {
+	Format string
+}
 
 func init() {
 	inspectCmd := &cobra.Command{
@@ -14,18 +21,156 @@ func init() {
 		Short: "inspect <ref>",
 		Long:  ``,
 		Args:  cobra.ExactArgs(1),
-		Run:   inspectApp,
+	}
+	opts := inspectOptions{}
+	inspectCmd.Flags().StringVar(&opts.Format, "format", "plain",
+		"Output format; supported: plain, json")
+	inspectCmd.Run = func(cmd *cobra.Command, args []string) {
+		if opts.Format != "plain" && opts.Format != "json" {
+			DieNotNil(cmd.Usage())
+			fmt.Fprintf(os.Stderr, "unsupported  `--format` value: %s\n", opts.Format)
+			os.Exit(1)
+		}
+		inspectApp(cmd, args, &opts)
 	}
 	rootCmd.AddCommand(inspectCmd)
 }
 
-func inspectApp(cmd *cobra.Command, args []string) {
+func inspectApp(cmd *cobra.Command, args []string, opts *inspectOptions) {
 	appRef := args[0]
 
-	fmt.Printf("Inspecting App %s...", appRef)
+	if opts.Format == "plain" {
+		fmt.Printf("Inspecting App %s...", appRef)
+	}
 	app, err := v1.NewAppLoader().LoadAppTree(cmd.Context(), compose.NewRemoteBlobProviderFromConfig(config), platforms.All, appRef)
 	DieNotNil(err)
-	fmt.Println("ok")
-	app.Tree().Print()
-	fmt.Printf("App tree node count: %d\n", app.NodeCount())
+	if opts.Format == "plain" {
+		fmt.Println("ok")
+		app.Tree().Print()
+	} else {
+		// json
+		type BlobInfo struct {
+			Digest string `json:"digest"`
+			Size   int64  `json:"size"`
+		}
+
+		type ManifestInfo struct {
+			BlobInfo
+			Architecture string     `json:"architecture,omitempty"`
+			Config       BlobInfo   `json:"config"`
+			Layers       []BlobInfo `json:"layers"`
+		}
+
+		type ImageContentInfo struct {
+			Ref       string         `json:"ref"`
+			Manifests []ManifestInfo `json:"manifests"`
+		}
+
+		type ServiceContentInfo struct {
+			Name  string           `json:"name"`
+			Image ImageContentInfo `json:"image"`
+		}
+
+		type BundleInfo struct {
+			BlobInfo
+			Services []ServiceContentInfo `json:"services,omitempty"`
+		}
+
+		type AppInfo struct {
+			Name   string     `json:"name"`
+			Ref    string     `json:"ref"`
+			Meta   BlobInfo   `json:"meta"`
+			Index  BlobInfo   `json:"index"`
+			Bundle BundleInfo `json:"bundle"`
+		}
+
+		currApp := AppInfo{
+			Name: app.Name(),
+			Ref:  app.Ref().Spec.String(),
+		}
+		currApp.Bundle = BundleInfo{
+			Services: []ServiceContentInfo{},
+		}
+
+		err = app.Tree().Walk(func(node *compose.TreeNode, depth int) error {
+			if depth == 1 {
+				switch node.Type {
+				case compose.BlobTypeAppLayersMeta:
+					currApp.Meta = BlobInfo{
+						Digest: node.Descriptor.Digest.String(),
+						Size:   node.Descriptor.Size,
+					}
+				case compose.BlobTypeAppIndex:
+					currApp.Index = BlobInfo{
+						Digest: node.Descriptor.Digest.String(),
+						Size:   node.Descriptor.Size,
+					}
+				case compose.BlobTypeAppBundle:
+					currApp.Bundle = BundleInfo{
+						BlobInfo: BlobInfo{
+							Digest: node.Descriptor.Digest.String(),
+							Size:   node.Descriptor.Size,
+						},
+						Services: []ServiceContentInfo{},
+					}
+				}
+			} else if depth == 2 {
+				var manifests []ManifestInfo
+				if node.Type == compose.BlobTypeImageManifest {
+					manifestInfo := ManifestInfo{
+						BlobInfo: BlobInfo{
+							Digest: node.Descriptor.Digest.String(),
+							Size:   node.Descriptor.Size,
+						},
+						// If an image manifest is found at depth 2,
+						// then there is no platform information available, as the manifest is not part of an image index.
+						Architecture: "unknown",
+					}
+					manifests = append(manifests, manifestInfo)
+				}
+				serviceInfo := ServiceContentInfo{
+					Name: node.Descriptor.Annotations[v1.AnnotationKeyAppServiceName],
+					Image: ImageContentInfo{
+						Ref:       node.Descriptor.URLs[0],
+						Manifests: manifests,
+					},
+				}
+				currApp.Bundle.Services = append(currApp.Bundle.Services, serviceInfo)
+			} else if depth == 3 && node.Type == compose.BlobTypeImageManifest {
+				manifestInfo := ManifestInfo{
+					BlobInfo: BlobInfo{
+						Digest: node.Descriptor.Digest.String(),
+						Size:   node.Descriptor.Size,
+					},
+					Architecture: node.Descriptor.Platform.Architecture,
+				}
+				lastIndex := &currApp.Bundle.Services[len(currApp.Bundle.Services)-1]
+				lastIndex.Image.Manifests = append(lastIndex.Image.Manifests, manifestInfo)
+			} else if depth == 4 || depth == 3 {
+				switch node.Type {
+				case compose.BlobTypeImageConfig:
+					lastIndex := &currApp.Bundle.Services[len(currApp.Bundle.Services)-1]
+					lastIndex.Image.Manifests[len(lastIndex.Image.Manifests)-1].Config = BlobInfo{
+						Digest: node.Descriptor.Digest.String(),
+						Size:   node.Descriptor.Size,
+					}
+				case compose.BlobTypeImageLayer:
+					lastIndex := &currApp.Bundle.Services[len(currApp.Bundle.Services)-1]
+					lastIndex.Image.Manifests[len(lastIndex.Image.Manifests)-1].Layers = append(lastIndex.Image.Manifests[len(lastIndex.Image.Manifests)-1].Layers, BlobInfo{
+						Digest: node.Descriptor.Digest.String(),
+						Size:   node.Descriptor.Size,
+					})
+				}
+			}
+			return nil
+		})
+		DieNotNil(err)
+
+		b, err := json.Marshal(currApp)
+		DieNotNil(err)
+		fmt.Println(string(b))
+	}
+	if opts.Format == "plain" {
+		fmt.Printf("App tree node count: %d\n", app.NodeCount())
+	}
 }

--- a/pkg/compose/v1/app.go
+++ b/pkg/compose/v1/app.go
@@ -65,6 +65,7 @@ const (
 
 	AnnotationKeyAppBundleIndexDigest = "org.foundries.app.bundle.index.digest"
 	AnnotationKeyAppBundleIndexSize   = "org.foundries.app.bundle.index.size"
+	AnnotationKeyAppServiceName       = "org.foundries.app.service.name"
 
 	StoreTypeSkopeo     = "skopeo store"
 	StoreTypeComposeCtl = "composectl store"
@@ -187,6 +188,7 @@ func (l *appLoader) LoadAppTree(ctx context.Context, provider compose.BlobProvid
 				imageTree.Descriptor.Annotations[AppServiceHashLabelKey] = srvHash
 			}
 		}
+		imageTree.Descriptor.Annotations[AnnotationKeyAppServiceName] = service.Name
 		composeTree.Children = append(composeTree.Children, imageTree)
 	}
 	appTree.Children = append(appTree.Children, &composeTree)


### PR DESCRIPTION
@mike-sul here is an example output. My priority was to get something out to unblock the new tests, I'm sure you will have suggestions for improvements in the json format. "indexes" is particularly not a good name IMO.

Also, we may want to move part of the new code to `pkg/compose/app.go`

```
{
  "name": "shellhttpd_base_10000",
  "ref": "hub.foundries.io/detsch-temp-test-1/shellhttpd_base_10000@sha256:643ec5ca445dcccba14f3ce704f6b7d4ad80756047dbcee4fd1ab938a10a5a41",
  "meta": {
    "type": "app meta",
    "digest": "sha256:d0f98c59b144cd1f769074d64d483fa267150a30043f63a5a4ebf8646493df67",
    "size": 294
  },
  "index": {
    "type": "app index",
    "digest": "sha256:247d5eb89ba605f426455a5238510d166595ab520bad3dfdcae5ae6219b2eeeb",
    "size": 757
  },
  "bundle": {
    "type": "app bundle",
    "digest": "sha256:66946ccde0f071bbbd49d5e5bf2d0c27a1a8500b683ab3800429255c15c26f3a",
    "size": 1039
  },
  "indexes": [
    {
      "index": {
        "type": "index",
        "digest": "sha256:98e4fcf4df5e67ec7dcb4efb83d4d5b3dc8ca85a1fc792d4a4806e92e26228c4",
        "size": 433
      },
      "manifest": {
        "type": "manifest",
        "digest": "sha256:bb28ee97ff89067d391e838cef15f80dd77659f4d5f23f2af15f48998428c0e8",
        "size": 696
      },
      "blobs": [
        {
          "type": "config",
          "digest": "sha256:312c4b1d9d21667e7483409396b8a8c3deb3236063471c92245fba4970141e6e",
          "size": 808
        },
        {
          "type": "layer",
          "digest": "sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870",
          "size": 3642247
        },
        {
          "type": "layer",
          "digest": "sha256:616b7f571c8ee24772b38ccfb5418fccee5bdf443af4f89b2f76e48cd9b3af09",
          "size": 387
        }
      ]
    },
    {
      "index": {
        "type": "index",
        "digest": "sha256:98e4fcf4df5e67ec7dcb4efb83d4d5b3dc8ca85a1fc792d4a4806e92e26228c4",
        "size": 433
      },
      "manifest": {
        "type": "manifest",
        "digest": "sha256:bb28ee97ff89067d391e838cef15f80dd77659f4d5f23f2af15f48998428c0e8",
        "size": 696
      },
      "blobs": [
        {
          "type": "config",
          "digest": "sha256:312c4b1d9d21667e7483409396b8a8c3deb3236063471c92245fba4970141e6e",
          "size": 808
        },
        {
          "type": "layer",
          "digest": "sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870",
          "size": 3642247
        },
        {
          "type": "layer",
          "digest": "sha256:616b7f571c8ee24772b38ccfb5418fccee5bdf443af4f89b2f76e48cd9b3af09",
          "size": 387
        }
      ]
    },
    {
      "index": {
        "type": "index",
        "digest": "sha256:98e4fcf4df5e67ec7dcb4efb83d4d5b3dc8ca85a1fc792d4a4806e92e26228c4",
        "size": 433
      },
      "manifest": {
        "type": "manifest",
        "digest": "sha256:bb28ee97ff89067d391e838cef15f80dd77659f4d5f23f2af15f48998428c0e8",
        "size": 696
      },
      "blobs": [
        {
          "type": "config",
          "digest": "sha256:312c4b1d9d21667e7483409396b8a8c3deb3236063471c92245fba4970141e6e",
          "size": 808
        },
        {
          "type": "layer",
          "digest": "sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870",
          "size": 3642247
        },
        {
          "type": "layer",
          "digest": "sha256:616b7f571c8ee24772b38ccfb5418fccee5bdf443af4f89b2f76e48cd9b3af09",
          "size": 387
        }
      ]
    },
    {
      "index": {
        "type": "index",
        "digest": "sha256:98e4fcf4df5e67ec7dcb4efb83d4d5b3dc8ca85a1fc792d4a4806e92e26228c4",
        "size": 433
      },
      "manifest": {
        "type": "manifest",
        "digest": "sha256:bb28ee97ff89067d391e838cef15f80dd77659f4d5f23f2af15f48998428c0e8",
        "size": 696
      },
      "blobs": [
        {
          "type": "config",
          "digest": "sha256:312c4b1d9d21667e7483409396b8a8c3deb3236063471c92245fba4970141e6e",
          "size": 808
        },
        {
          "type": "layer",
          "digest": "sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870",
          "size": 3642247
        },
        {
          "type": "layer",
          "digest": "sha256:616b7f571c8ee24772b38ccfb5418fccee5bdf443af4f89b2f76e48cd9b3af09",
          "size": 387
        }
      ]
    },
    {
      "index": {
        "type": "index",
        "digest": "sha256:98e4fcf4df5e67ec7dcb4efb83d4d5b3dc8ca85a1fc792d4a4806e92e26228c4",
        "size": 433
      },
      "manifest": {
        "type": "manifest",
        "digest": "sha256:bb28ee97ff89067d391e838cef15f80dd77659f4d5f23f2af15f48998428c0e8",
        "size": 696
      },
      "blobs": [
        {
          "type": "config",
          "digest": "sha256:312c4b1d9d21667e7483409396b8a8c3deb3236063471c92245fba4970141e6e",
          "size": 808
        },
        {
          "type": "layer",
          "digest": "sha256:f18232174bc91741fdf3da96d85011092101a032a93a388b79e99e69c2d5c870",
          "size": 3642247
        },
        {
          "type": "layer",
          "digest": "sha256:616b7f571c8ee24772b38ccfb5418fccee5bdf443af4f89b2f76e48cd9b3af09",
          "size": 387
        }
      ]
    }
  ]
}
` ``