### PR TITLE
compose: adjust image load options for containerd storage

### DIFF
--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -144,6 +144,8 @@ func LoadImages(ctx context.Context,
 		defer options.ProgressReporter.Stop(true)
 	}
 
+	isCtrd := adjustOptionsIfContainerd(ctx, client, options)
+
 	imageLoadManifests, imageURIs, layersMap, err := generateImageLoadingManifestForApp(ctx, app, blobsRoot, options)
 	if err != nil {
 		return fmt.Errorf("failed to generate image load manifests: %w", err)
@@ -200,6 +202,12 @@ func LoadImages(ctx context.Context,
 		return err
 	}
 	defer r.Body.Close()
+
+	if isCtrd {
+		// Containerd doesn't support progress reporting, so we can return early.
+		return nil
+	}
+
 	// TODO: Read and process the image load progress messages from the response body `r.Body`
 	dec := json.NewDecoder(r.Body)
 
@@ -429,4 +437,30 @@ func getImageID(imageURIs []imageURI2RefCounter, imageIndex int, printWarning bo
 		fmt.Printf("Warning: image index %d is out of range (max %d)\n", imageIndex, len(imageURIs))
 	}
 	return "unknown"
+}
+
+func adjustOptionsIfContainerd(ctx context.Context, client *client.Client, options *LoadImageOptions) bool {
+	var isCtrd = false
+	// Check if the docker daemon is using ctrd storage, which requires special handling when loading images.
+	if dockerInfo, err := client.Info(ctx); err == nil {
+		if dockerInfo.Driver == "overlayfs" &&
+			len(dockerInfo.DriverStatus) > 0 &&
+			dockerInfo.DriverStatus[0][1] == "io.containerd.snapshotter.v1" {
+			isCtrd = true
+		}
+	}
+
+	if isCtrd {
+		if options.ReadBlobsFromStore {
+			// The ctrd storage does not support loading image layers from an external directory,
+			// thus, the image load will fail if `options.ReadBlobsFromStore` is set.
+			options.ReadBlobsFromStore = false
+		}
+		if options.ProgressReporter != nil {
+			// The ctrd storage does not support reporting progress of loading image layers, thus, disable progress reporting to avoid confusion.
+			options.ProgressReporter = nil
+		}
+	}
+
+	return isCtrd
 }

--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -211,107 +211,10 @@ func LoadImages(ctx context.Context,
 
 	if isCtrd {
 		return reportProgressIfContainerd(r.Body, imageURIs, options.ProgressReporter)
+	} else {
+		return reportProgressIfDocker(r.Body, imageURIs, layersMap, options)
 	}
 
-	// TODO: Read and process the image load progress messages from the response body `r.Body`
-	dec := json.NewDecoder(r.Body)
-
-	curImageIndex := 0
-	curLayerID := ""
-	p := &LoadImageProgress{
-		State:   ImageLoadStateImageWaiting,
-		ImageID: imageURIs[curImageIndex].URI,
-	}
-
-	for {
-		var jm jsonmessage.JSONMessage
-		// Decode the next message from the response body
-		if decodeErr := dec.Decode(&jm); decodeErr != nil {
-			if decodeErr != io.EOF {
-				// An error occurred while decoding the message, except for EOF
-				err = decodeErr
-			}
-			break
-		}
-		if jm.Error != nil {
-			err = fmt.Errorf("dockerd err: %s", jm.Error)
-			break
-		}
-
-		switch p.State {
-		case ImageLoadStateImageWaiting:
-			{
-				if jm.Progress == nil {
-					if imageURIs[curImageIndex].refCounter--; imageURIs[curImageIndex].refCounter == 0 {
-						p.State = ImageLoadStateImageExist
-						reportProgressIfEnabled(options, p)
-
-						curImageIndex++
-						curLayerID = ""
-						p.State = ImageLoadStateImageWaiting
-						p.ImageID = getImageID(imageURIs, curImageIndex, false)
-					}
-				} else {
-					curLayerID = jm.ID
-					p.ImageID = getImageID(imageURIs, curImageIndex, true)
-					if _, ok := layersMap[curLayerID]; ok {
-						p.ID = layersMap[curLayerID][:7]
-					} else {
-						p.ID = "unknown"
-					}
-					p.State = ImageLoadStateLayerLoading
-					p.Current = jm.Progress.Current
-					p.Total = jm.Progress.Total
-					reportProgressIfEnabled(options, p)
-				}
-			}
-		case ImageLoadStateLayerLoading:
-			{
-				p.Current = jm.Progress.Current
-				p.Total = jm.Progress.Total
-				reportProgressIfEnabled(options, p)
-				if jm.Progress.Current == jm.Progress.Total {
-					// Image layer files were extracted and written to filesystem, now fsyncing has started
-					// Unfortunately, we cannot track progress of fsyncing, so we just report the state
-					p.State = ImageLoadStateLayerSyncing
-					reportProgressIfEnabled(options, p)
-				}
-			}
-		case ImageLoadStateLayerSyncing:
-			{
-				if jm.Progress == nil {
-					if imageURIs[curImageIndex].refCounter--; imageURIs[curImageIndex].refCounter == 0 {
-						p.State = ImageLoadStateImageLoaded
-						reportProgressIfEnabled(options, p)
-
-						curImageIndex++
-						curLayerID = ""
-						p.ImageID = getImageID(imageURIs, curImageIndex, false)
-						p.State = ImageLoadStateImageWaiting
-					}
-
-				} else if curLayerID != jm.ID {
-					p.State = ImageLoadStateLayerLoaded
-					reportProgressIfEnabled(options, p)
-
-					// Start new image layer loading
-					curLayerID = jm.ID
-					if _, ok := layersMap[curLayerID]; ok {
-						p.ID = layersMap[curLayerID][:7]
-					} else {
-						p.ID = "unknown"
-					}
-					p.State = ImageLoadStateLayerLoading
-
-					p.Current = jm.Progress.Current
-					p.Total = jm.Progress.Total
-					reportProgressIfEnabled(options, p)
-				}
-			}
-		}
-	}
-
-	return err
 }
 
 func reportProgressIfEnabled(opts *LoadImageOptions, p *LoadImageProgress) {
@@ -515,4 +418,105 @@ func reportProgressIfContainerd(body io.ReadCloser, imageURIs []imageURI2RefCoun
 		}
 	}
 	return nil
+}
+
+func reportProgressIfDocker(body io.ReadCloser, imageURIs []imageURI2RefCounter, layersMap map[string]string, options *LoadImageOptions) error {
+	var err error
+	dec := json.NewDecoder(body)
+
+	curImageIndex := 0
+	curLayerID := ""
+	p := &LoadImageProgress{
+		State:   ImageLoadStateImageWaiting,
+		ImageID: imageURIs[curImageIndex].URI,
+	}
+
+	for {
+		var jm jsonmessage.JSONMessage
+		// Decode the next message from the response body
+		if decodeErr := dec.Decode(&jm); decodeErr != nil {
+			if decodeErr != io.EOF {
+				// An error occurred while decoding the message, except for EOF
+				err = decodeErr
+			}
+			break
+		}
+		if jm.Error != nil {
+			err = fmt.Errorf("dockerd err: %s", jm.Error)
+			break
+		}
+
+		switch p.State {
+		case ImageLoadStateImageWaiting:
+			{
+				if jm.Progress == nil {
+					if imageURIs[curImageIndex].refCounter--; imageURIs[curImageIndex].refCounter == 0 {
+						p.State = ImageLoadStateImageExist
+						reportProgressIfEnabled(options, p)
+
+						curImageIndex++
+						curLayerID = ""
+						p.State = ImageLoadStateImageWaiting
+						p.ImageID = getImageID(imageURIs, curImageIndex, false)
+					}
+				} else {
+					curLayerID = jm.ID
+					p.ImageID = getImageID(imageURIs, curImageIndex, true)
+					if _, ok := layersMap[curLayerID]; ok {
+						p.ID = layersMap[curLayerID][:7]
+					} else {
+						p.ID = "unknown"
+					}
+					p.State = ImageLoadStateLayerLoading
+					p.Current = jm.Progress.Current
+					p.Total = jm.Progress.Total
+					reportProgressIfEnabled(options, p)
+				}
+			}
+		case ImageLoadStateLayerLoading:
+			{
+				p.Current = jm.Progress.Current
+				p.Total = jm.Progress.Total
+				reportProgressIfEnabled(options, p)
+				if jm.Progress.Current == jm.Progress.Total {
+					// Image layer files were extracted and written to filesystem, now fsyncing has started
+					// Unfortunately, we cannot track progress of fsyncing, so we just report the state
+					p.State = ImageLoadStateLayerSyncing
+					reportProgressIfEnabled(options, p)
+				}
+			}
+		case ImageLoadStateLayerSyncing:
+			{
+				if jm.Progress == nil {
+					if imageURIs[curImageIndex].refCounter--; imageURIs[curImageIndex].refCounter == 0 {
+						p.State = ImageLoadStateImageLoaded
+						reportProgressIfEnabled(options, p)
+
+						curImageIndex++
+						curLayerID = ""
+						p.ImageID = getImageID(imageURIs, curImageIndex, false)
+						p.State = ImageLoadStateImageWaiting
+					}
+
+				} else if curLayerID != jm.ID {
+					p.State = ImageLoadStateLayerLoaded
+					reportProgressIfEnabled(options, p)
+
+					// Start new image layer loading
+					curLayerID = jm.ID
+					if _, ok := layersMap[curLayerID]; ok {
+						p.ID = layersMap[curLayerID][:7]
+					} else {
+						p.ID = "unknown"
+					}
+					p.State = ImageLoadStateLayerLoading
+
+					p.Current = jm.Progress.Current
+					p.Total = jm.Progress.Total
+					reportProgressIfEnabled(options, p)
+				}
+			}
+		}
+	}
+	return err
 }

--- a/pkg/compose/image_loader.go
+++ b/pkg/compose/image_loader.go
@@ -4,9 +4,11 @@ import (
 	"archive/tar"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"path"
+	"strings"
 
 	"github.com/docker/docker/client"
 	"github.com/docker/docker/pkg/jsonmessage"
@@ -81,6 +83,7 @@ const (
 	ImageLoadStateLayerLoading ImageLoadState = "image-load:layer:loading"
 	ImageLoadStateLayerSyncing ImageLoadState = "image-load:layer:syncing"
 	ImageLoadStateLayerLoaded  ImageLoadState = "image-load:layer:loaded"
+	ImageLoadStateImageLoading ImageLoadState = "image-load:image:loading"
 	ImageLoadStateImageLoaded  ImageLoadState = "image-load:image:loaded"
 	ImageLoadStateImageExist   ImageLoadState = "image-load:image:exist"
 )
@@ -197,6 +200,9 @@ func LoadImages(ctx context.Context,
 		}
 	}()
 
+	if isCtrd && options.ProgressReporter != nil {
+		options.ProgressReporter.Update(LoadImageProgress{State: ImageLoadStateImageLoading, ImageID: imageURIs[0].URI})
+	}
 	r, err := client.ImageLoad(ctx, ts.Reader(), false)
 	if err != nil {
 		return err
@@ -204,8 +210,7 @@ func LoadImages(ctx context.Context,
 	defer r.Body.Close()
 
 	if isCtrd {
-		// Containerd doesn't support progress reporting, so we can return early.
-		return nil
+		return reportProgressIfContainerd(r.Body, imageURIs, options.ProgressReporter)
 	}
 
 	// TODO: Read and process the image load progress messages from the response body `r.Body`
@@ -456,11 +461,58 @@ func adjustOptionsIfContainerd(ctx context.Context, client *client.Client, optio
 			// thus, the image load will fail if `options.ReadBlobsFromStore` is set.
 			options.ReadBlobsFromStore = false
 		}
-		if options.ProgressReporter != nil {
-			// The ctrd storage does not support reporting progress of loading image layers, thus, disable progress reporting to avoid confusion.
-			options.ProgressReporter = nil
-		}
 	}
 
 	return isCtrd
+}
+
+func reportProgressIfContainerd(body io.ReadCloser, imageURIs []imageURI2RefCounter, reporter progress.Reporter[LoadImageProgress]) error {
+	// Currently, dockerd using the containerd image store does not provide proper
+	// progress reporting for image loads. As a workaround, parse the response body
+	// and derive progress updates from messages emitted by the current dockerd implementation.
+	//
+	// In particular, progress is inferred from the "Loaded image:" message, which
+	// indicates that an image has been imported successfully:
+	// https://github.com/moby/moby/blob/88e3f1c86461a796a9164d4c7dde72e77339eae4/daemon/containerd/image_exporter.go#L394
+	//
+	// Proper progress support is being tracked in: https://github.com/moby/moby/issues/43910
+	// Ongoing implementation: https://github.com/moby/moby/pull/50250
+	// Revisit this logic once the proper progress reporting becomes available.
+	dec := json.NewDecoder(body)
+
+	for {
+		var jm jsonmessage.JSONMessage
+		// Decode the next message from the response body
+		err := dec.Decode(&jm)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("failed to decode containerd response: %w", err)
+		}
+		if strings.HasPrefix(jm.Stream, "Error unpacking image") {
+			return fmt.Errorf("error unpacking image: %s", jm.Stream)
+		}
+		if strings.HasPrefix(jm.Stream, "Loaded image: ") {
+			imageRef := strings.TrimPrefix(jm.Stream, "Loaded image: ")
+			// Remove end line character if present
+			imageRef = strings.TrimSuffix(imageRef, "\n")
+			for indx, img := range imageURIs {
+				if img.URI == imageRef {
+					reporter.Update(LoadImageProgress{
+						State:   ImageLoadStateImageLoaded,
+						ImageID: img.URI,
+					})
+					if indx < len(imageURIs)-1 {
+						reporter.Update(LoadImageProgress{
+							State:   ImageLoadStateImageLoading,
+							ImageID: imageURIs[indx+1].URI,
+						})
+					}
+					break
+				}
+			}
+		}
+	}
+	return nil
 }

--- a/pkg/update/status_printer.go
+++ b/pkg/update/status_printer.go
@@ -181,6 +181,13 @@ func GetInstallProgressPrinter(options ...ProgressPrinterOption) func(status *co
 
 func renderImageLoadingProgress(ctx *imageLoadingContext, p *compose.InstallProgress, indentation int) {
 	switch p.ImageLoadState {
+	case compose.ImageLoadStateImageLoading:
+		{
+			if ctx.curImageID != p.ImageID {
+				fmt.Printf("%*sLoading image %s", indentation, "", p.ImageID)
+				ctx.curImageID = p.ImageID
+			}
+		}
 	case compose.ImageLoadStateLayerLoading:
 		{
 			if ctx.curImageID != p.ImageID {


### PR DESCRIPTION
Detect when the Docker daemon is backed by containerd snapshotter storage and apply compatible image load behavior and progress reporting.

This prevents load failures and avoids misleading progress reporting when running against containerd-backed Docker engines.